### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/874/835/101874835.geojson
+++ b/data/101/874/835/101874835.geojson
@@ -44,6 +44,9 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4f478e4898af4d68d08046fb3182381",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":101874835,
-    "wof:lastmodified":1566600308,
+    "wof:lastmodified":1582358357,
     "wof:name":"Paranho de Areia",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/919/427/101919427.geojson
+++ b/data/101/919/427/101919427.geojson
@@ -347,6 +347,9 @@
         "wd:id":"Q41211"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d113f9f71ff8db0fe188e0bb78a3bada",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         }
     ],
     "wof:id":101919427,
-    "wof:lastmodified":1566600331,
+    "wof:lastmodified":1582358358,
     "wof:name":"San Juan",
     "wof:parent_id":102080441,
     "wof:placetype":"locality",

--- a/data/856/873/31/85687331.geojson
+++ b/data/856/873/31/85687331.geojson
@@ -32,7 +32,7 @@
     "qs:type":"G4000",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "uscensus-display-terrestrial-zoom-10"
+        "uscensus"
     ],
     "src:lbl:centroid":"mapshaper",
     "wd:wordcount":26658,
@@ -46,6 +46,9 @@
         "wd:id":"Q1183"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "uscensus-display-terrestrial-zoom-10"
+    ],
     "wof:geomhash":"2b9bb3ca0e4b20f523ec20a7840e18af",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1532035626,
+    "wof:lastmodified":1582358353,
     "wof:name":"Puerto Rico",
     "wof:parent_id":85633729,
     "wof:placetype":"region",

--- a/data/857/940/87/85794087.geojson
+++ b/data/857/940/87/85794087.geojson
@@ -102,6 +102,9 @@
         "qs_pg:id":249472
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a99fd589545ecdabaf3d2c95e4b0d628",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"San Jose",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/857/988/37/85798837.geojson
+++ b/data/857/988/37/85798837.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Aldoar"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1446dac85c3d7d4849d3036a1cb4ecbb",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"Aldoar",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/989/25/85798925.geojson
+++ b/data/857/989/25/85798925.geojson
@@ -111,6 +111,9 @@
         "qs_pg:id":1084304
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37f1592cbaac6d55e6846dcaf46bd867",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"Bom Jesus",
     "wof:parent_id":101759281,
     "wof:placetype":"neighbourhood",

--- a/data/857/989/31/85798931.geojson
+++ b/data/857/989/31/85798931.geojson
@@ -117,6 +117,9 @@
         "qs_pg:id":483892
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"545b884e102a8931de7c234ba4716565",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"Bonfim",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/989/65/85798965.geojson
+++ b/data/857/989/65/85798965.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":479035
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d293afe7ceb2e0141e6cd70c5a2a8c8",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"Candal",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/01/85799001.geojson
+++ b/data/857/990/01/85799001.geojson
@@ -111,6 +111,9 @@
         "qs_pg:id":891927
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b56360ba472c534070185db35697de4f",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358352,
     "wof:name":"Lapa",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/05/85799005.geojson
+++ b/data/857/990/05/85799005.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":217226
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"631be146e3fb69485710e6a3140dfc1b",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358352,
     "wof:name":"Lavadores",
     "wof:parent_id":101752095,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/13/85799013.geojson
+++ b/data/857/990/13/85799013.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Lordelo do Ouro"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03598fe9554b775f8b5d30031713f484",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"Lordelo do Ouro",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/29/85799029.geojson
+++ b/data/857/990/29/85799029.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Mafamude"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca2179369cb24b48475b2326f50b9152",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358352,
     "wof:name":"Mafamude",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/63/85799063.geojson
+++ b/data/857/990/63/85799063.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":141253
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0dbe50817e440ee964e7734bb7f14ba9",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":85799063,
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"Oliveira do Douro",
     "wof:parent_id":101752095,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/85/85799085.geojson
+++ b/data/857/990/85/85799085.geojson
@@ -68,6 +68,9 @@
         "gp:id":746031
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"662d91a25f2f57a95f9ab68509ddd017",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"Ponte da Arrabi",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/95/85799095.geojson
+++ b/data/857/990/95/85799095.geojson
@@ -123,6 +123,9 @@
         "wk:page":"Ramalde"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"495c6dfabcaf5f349768e31440661903",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600224,
+    "wof:lastmodified":1582358352,
     "wof:name":"Ramalde",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/39/85859539.geojson
+++ b/data/858/595/39/85859539.geojson
@@ -100,6 +100,9 @@
         "wd:id":"Q3783649"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"73deb6fac3d96917e0c6aad7dd507e63",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358353,
     "wof:name":"Hato Rey",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/43/85859543.geojson
+++ b/data/858/595/43/85859543.geojson
@@ -95,6 +95,9 @@
         "wd:id":"Q511729"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7c7bf3c991dda3cf73bbbd000c936be",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358353,
     "wof:name":"Santurce",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/45/85859545.geojson
+++ b/data/858/595/45/85859545.geojson
@@ -111,6 +111,9 @@
         "wd:id":"Q1136674"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"146d2bd62cd1d84f8d0649b61509085d",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"Old San Juan",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/47/85859547.geojson
+++ b/data/858/595/47/85859547.geojson
@@ -161,6 +161,9 @@
         "wd:id":"Q344554"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8a759a1b39563a29d3680e6b57cf49c8",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358353,
     "wof:name":"Fernandez Juncos",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/51/85859551.geojson
+++ b/data/858/595/51/85859551.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1084654
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee0c13aefa95b3b4048374317fe7c0e6",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600225,
+    "wof:lastmodified":1582358353,
     "wof:name":"65 de Infanteria",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/55/85859555.geojson
+++ b/data/858/595/55/85859555.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q7258533"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ca46a31500817f44a10248f79be169c",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358353,
     "wof:name":"Puerta de Tierra",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/625/97/85862597.geojson
+++ b/data/858/625/97/85862597.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":1179658
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59be984cb37264aaaef09a69e26a7203",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358353,
     "wof:name":"Amial",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/39/85866239.geojson
+++ b/data/858/662/39/85866239.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1121239
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa13fb64bce82f20a78ffa559ac141d8",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Zenon Diaz Valcarcel",
     "wof:parent_id":101919293,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/41/85866241.geojson
+++ b/data/858/662/41/85866241.geojson
@@ -75,6 +75,9 @@
         "qs:id":10231
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1afd7a5c660460d73eb4813dc8f43ac",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379432,
+    "wof:lastmodified":1582358355,
     "wof:name":"Vietnam",
     "wof:parent_id":101918955,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/43/85866243.geojson
+++ b/data/858/662/43/85866243.geojson
@@ -159,6 +159,9 @@
         "qs_pg:id":483526
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8922888ae02e2857624de54dcc5d28bb",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Amelia",
     "wof:parent_id":101918955,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/45/85866245.geojson
+++ b/data/858/662/45/85866245.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1103294
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0df71f1a17d176e77d11f70f562002d0",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Zona Portuaria",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/47/85866247.geojson
+++ b/data/858/662/47/85866247.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":954961
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00b4a34592c3f4a47299237bb5dcd906",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600230,
+    "wof:lastmodified":1582358355,
     "wof:name":"San Juan Antiguo",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/49/85866249.geojson
+++ b/data/858/662/49/85866249.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Miramar (Santurce)"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d16453724958c98de4309ed5f6d964f8",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1561827121,
+    "wof:lastmodified":1582358355,
     "wof:name":"Miramar",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/51/85866251.geojson
+++ b/data/858/662/51/85866251.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Condado (Santurce)"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"02aecaff433810d7deca13421dad4a87",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358355,
     "wof:name":"Condado",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/53/85866253.geojson
+++ b/data/858/662/53/85866253.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":1193300
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa87bc06b7a35ec0000a428ecd8235b9",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Tras Talleres",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/57/85866257.geojson
+++ b/data/858/662/57/85866257.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1064850
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f54bd54ef01c14619c325170aa42dbdd",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358354,
     "wof:name":"Industrial Tres Monjitas",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/59/85866259.geojson
+++ b/data/858/662/59/85866259.geojson
@@ -99,6 +99,9 @@
         "qs_pg:id":1193302
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c95434fd174eeb48b05cdc9116d64380",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358354,
     "wof:name":"Monte Flores",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/61/85866261.geojson
+++ b/data/858/662/61/85866261.geojson
@@ -81,6 +81,9 @@
         "qs_pg:id":1330221
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f8b28c0bfb42ef3d8c1f12c3f07e7c6",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358354,
     "wof:name":"Park Boulevard",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/63/85866263.geojson
+++ b/data/858/662/63/85866263.geojson
@@ -80,6 +80,9 @@
         "qs:id":1330399
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d282a696ca0f77d7c37936aadd13c25",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379432,
+    "wof:lastmodified":1582358355,
     "wof:name":"Martin Pena",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/65/85866265.geojson
+++ b/data/858/662/65/85866265.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":1193322
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e2d52384d1d467b623799f5cafe3b33",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Residencial El Mirador",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/67/85866267.geojson
+++ b/data/858/662/67/85866267.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":1193323
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c050455244f2c1084edfefe8e2cf4f39",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358355,
     "wof:name":"Punta Las Marias",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/69/85866269.geojson
+++ b/data/858/662/69/85866269.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":224025
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1598ed29b19ede5059281208a9a54927",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358354,
     "wof:name":"Atlantic View",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/71/85866271.geojson
+++ b/data/858/662/71/85866271.geojson
@@ -114,6 +114,9 @@
         "qs_pg:id":1086158
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f327ffc175cc00dec7d1c602d5aabe49",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600230,
+    "wof:lastmodified":1582358355,
     "wof:name":"El Palmar",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/75/85866275.geojson
+++ b/data/858/662/75/85866275.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":1086159
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a1032e0b86d47f0f6e2f3ba03710cea",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Biascochea",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/77/85866277.geojson
+++ b/data/858/662/77/85866277.geojson
@@ -684,6 +684,9 @@
         "qs_pg:id":1086165
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28b30c55443ad5e8b00b2cd3ca1f66b6",
     "wof:hierarchy":[
         {
@@ -701,7 +704,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600230,
+    "wof:lastmodified":1582358355,
     "wof:name":"Los Angeles",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/79/85866279.geojson
+++ b/data/858/662/79/85866279.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1191362
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"42c502cd54162c65b26c349168ecce32",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Bahia Vistamar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/81/85866281.geojson
+++ b/data/858/662/81/85866281.geojson
@@ -99,6 +99,9 @@
         "qs_pg:id":888274
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6c369b64ae83d8fc2ae1f15e827e935",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Vistamar",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/83/85866283.geojson
+++ b/data/858/662/83/85866283.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":985483
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2bdd9ee80b66443320b71b178003bb9",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Caparra Arts.",
     "wof:parent_id":101919125,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/85/85866285.geojson
+++ b/data/858/662/85/85866285.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":230050
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e04627b968ea6107963e15944d84bcaa",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600230,
+    "wof:lastmodified":1582358355,
     "wof:name":"Tintillo Hills",
     "wof:parent_id":101919125,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/87/85866287.geojson
+++ b/data/858/662/87/85866287.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":503558
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9fab5dbc1a28c28b6b609c8807d7cb55",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Prado Alto",
     "wof:parent_id":101919293,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/89/85866289.geojson
+++ b/data/858/662/89/85866289.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":989427
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d693b42b69d8ffb30112356423506492",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Martin's Court",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/93/85866293.geojson
+++ b/data/858/662/93/85866293.geojson
@@ -100,6 +100,9 @@
         "qs:id":1103594
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7ad586a3d40a00c126a125bf65fcf00",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379435,
+    "wof:lastmodified":1582358355,
     "wof:name":"Las Lomas",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/95/85866295.geojson
+++ b/data/858/662/95/85866295.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":401028
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f0c5bada3b279092be3a162c338c7ee",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358354,
     "wof:name":"Mansione de Garden Hills",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/97/85866297.geojson
+++ b/data/858/662/97/85866297.geojson
@@ -188,6 +188,9 @@
         "qs_pg:id":1103596
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"860b1dc13d1af468fe8e94703df4a62a",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600229,
+    "wof:lastmodified":1582358355,
     "wof:name":"Golden Gate",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/99/85866299.geojson
+++ b/data/858/662/99/85866299.geojson
@@ -76,6 +76,9 @@
         "qs:id":1193348
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77e9bb7cd5a3512a678cf56e5b1126e8",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379435,
+    "wof:lastmodified":1582358355,
     "wof:name":"Parkside",
     "wof:parent_id":101919293,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/01/85866301.geojson
+++ b/data/858/663/01/85866301.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":1002114
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3f11e3eb5d8502ea5922777f182cbc8",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"La Riviera",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/03/85866303.geojson
+++ b/data/858/663/03/85866303.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q7315422"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ced8a1084ec1b5692a77a493cb0c103f",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358354,
     "wof:name":"Residencial Nemesio Canales",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/05/85866305.geojson
+++ b/data/858/663/05/85866305.geojson
@@ -347,6 +347,9 @@
         "wd:id":"Q83396"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efed2cf51869522423b1e979de13d0a7",
     "wof:hierarchy":[
         {
@@ -364,7 +367,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358354,
     "wof:name":"Eleanor Roosevelt",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/07/85866307.geojson
+++ b/data/858/663/07/85866307.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":466561
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"633b5f92e5d6cb2e1aee528ab52ed980",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Las Americas",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/11/85866311.geojson
+++ b/data/858/663/11/85866311.geojson
@@ -211,6 +211,9 @@
         "qs_pg:id":466562
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"09de05175fdf48cc6b518be85a115615",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Santa Ana",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/13/85866313.geojson
+++ b/data/858/663/13/85866313.geojson
@@ -79,6 +79,9 @@
         "qs:id":503628
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff544804620a68d4bf09bcc5d0c46198",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379440,
+    "wof:lastmodified":1582358354,
     "wof:name":"El Vedado",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/15/85866315.geojson
+++ b/data/858/663/15/85866315.geojson
@@ -76,6 +76,9 @@
         "qs:id":1193387
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"097792f4506f5f0a6077cafda9919d71",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379440,
+    "wof:lastmodified":1582358354,
     "wof:name":"Baldrich",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/17/85866317.geojson
+++ b/data/858/663/17/85866317.geojson
@@ -92,6 +92,9 @@
         "qs_pg:id":1103305
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c19b0921a243f12825335b40890023a3",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Gonzalez",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/19/85866319.geojson
+++ b/data/858/663/19/85866319.geojson
@@ -93,6 +93,9 @@
         "wk:page":"L\u00f3pez Sicard\u00f3 (Oriente)"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d5a1cbd7545a01e4d79ee86afb7472d",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Lopez Sicardo",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/21/85866321.geojson
+++ b/data/858/663/21/85866321.geojson
@@ -101,6 +101,9 @@
         "wk:page":"R\u00edo Piedras, Puerto Rico"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75500b0e6b9b4edecca42a9f65bad5ba",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379437,
+    "wof:lastmodified":1582358354,
     "wof:name":"Rio Piedras",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/23/85866323.geojson
+++ b/data/858/663/23/85866323.geojson
@@ -759,6 +759,9 @@
         "qs_pg:id":1193379
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0409ec7ce8750fed5e805d66fb42f02",
     "wof:hierarchy":[
         {
@@ -776,7 +779,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Venezuela",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/25/85866325.geojson
+++ b/data/858/663/25/85866325.geojson
@@ -90,6 +90,9 @@
         "wk:page":"San Ant\u00f3n"
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f46153df41573ba26a3c5a5cf5639b2",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358354,
     "wof:name":"San Anton",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/29/85866329.geojson
+++ b/data/858/663/29/85866329.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":1193406
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b58f3b904fd6b13719725019a9212117",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Campo Rico",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/31/85866331.geojson
+++ b/data/858/663/31/85866331.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":84027
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6fabacb8a207c9fd36ccbc1cc52d7a6",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Extension El Comandante",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/33/85866333.geojson
+++ b/data/858/663/33/85866333.geojson
@@ -121,6 +121,9 @@
         "qs_pg:id":224028
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bac34597a3c5b59717db42ddaceb208f",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358354,
     "wof:name":"Las Cruces",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/35/85866335.geojson
+++ b/data/858/663/35/85866335.geojson
@@ -105,6 +105,9 @@
         "qs_pg:id":1193415
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34533ad2ce941fdefae17cfb801498ff",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358354,
     "wof:name":"Monte Bello",
     "wof:parent_id":101919293,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/37/85866337.geojson
+++ b/data/858/663/37/85866337.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":1002120
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"010730d48fcd6e1a4d1fd69c505eeda1",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Sierra Berdecia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/39/85866339.geojson
+++ b/data/858/663/39/85866339.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":219936
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d72524eb0a4dff5d582c5bf092957a68",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Mansiones de Guaynabo",
     "wof:parent_id":101919293,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/41/85866341.geojson
+++ b/data/858/663/41/85866341.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":967369
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a0769025cb69ef355c002ffa8ae62b3",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Monte Alvernia",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/43/85866343.geojson
+++ b/data/858/663/43/85866343.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":902671
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2598c49ad343c1261e678586a48f8c58",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Mansiones de Villanova",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/47/85866347.geojson
+++ b/data/858/663/47/85866347.geojson
@@ -109,6 +109,9 @@
         "qs_pg:id":902672
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dac4539b6ee8f9fc954093e2085c80be",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358354,
     "wof:name":"Romany",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/49/85866349.geojson
+++ b/data/858/663/49/85866349.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":230060
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"776aa9fe2435034afa8bfb49ade19a8e",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600228,
+    "wof:lastmodified":1582358354,
     "wof:name":"Extension San Gerardo",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/51/85866351.geojson
+++ b/data/858/663/51/85866351.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":1103611
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"36bd14974f64aa1829aae50b8101d9ed",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358354,
     "wof:name":"Villa Olga",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/53/85866353.geojson
+++ b/data/858/663/53/85866353.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":1197849
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ccb4bba53716c4bdea3dccbe872d642",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Los Choferes",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/55/85866355.geojson
+++ b/data/858/663/55/85866355.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":1193439
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4fe56d10c5f3e72d0d0abb22ecc96f27",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600227,
+    "wof:lastmodified":1582358354,
     "wof:name":"Residencial Interamericana",
     "wof:parent_id":101918965,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/57/85866357.geojson
+++ b/data/858/663/57/85866357.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":466564
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01303fb9874260c53af0094c9016f103",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358354,
     "wof:name":"Pedro Regalado Diaz",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/59/85866359.geojson
+++ b/data/858/663/59/85866359.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1079173
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ab32ae612dac1d7c0adb0949f372967",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600226,
+    "wof:lastmodified":1582358353,
     "wof:name":"Lago Alto",
     "wof:parent_id":101918965,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/61/85866361.geojson
+++ b/data/858/663/61/85866361.geojson
@@ -76,6 +76,9 @@
         "qs:id":888275
     },
     "wof:country":"PR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50b5eac41c189a822a72847e597ab7eb",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379443,
+    "wof:lastmodified":1582358353,
     "wof:name":"Bolling Hills",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.