### PR TITLE
Flag coterminous places

### DIFF
--- a/data/101/918/955/101918955.geojson
+++ b/data/101/918/955/101918955.geojson
@@ -92,17 +92,20 @@
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
-        85633729,
-        85687331,
         102191575,
+        102080289,
+        85633729,
         136253057,
-        102080289
+        85687331
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":160792,
         "wd:id":"Q768483"
     },
+    "wof:coterminous":[
+        102080289
+    ],
     "wof:country":"PR",
     "wof:geomhash":"09c811e6561f8fbb34381aeb8b63a3ee",
     "wof:hierarchy":[
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101918955,
-    "wof:lastmodified":1566600309,
+    "wof:lastmodified":1607986515,
     "wof:name":"Cata\u00f1o",
     "wof:parent_id":102080289,
     "wof:placetype":"locality",

--- a/data/102/080/289/102080289.geojson
+++ b/data/102/080/289/102080289.geojson
@@ -116,16 +116,19 @@
     "statoids:type":"municipality",
     "wd:wordcount":1716,
     "wof:belongsto":[
-        85633729,
-        85687331,
         102191575,
-        136253057
+        85633729,
+        136253057,
+        85687331
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"PR.CT",
         "wd:id":"Q768483"
     },
+    "wof:coterminous":[
+        101918955
+    ],
     "wof:country":"PR",
     "wof:geomhash":"034423e148ba9f107bcb14d70bd01eee",
     "wof:hierarchy":[
@@ -148,7 +151,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1566600192,
+    "wof:lastmodified":1607986515,
     "wof:name":"Cata\u00f1o",
     "wof:parent_id":85687331,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#1906.

This PR attempts flag any locality, localadmin, county, macrocounty, or region record as coterminous with any parent records that are similar in size and have similar names.