### PR TITLE
Update properties of megacities

### DIFF
--- a/data/101/919/427/101919427.geojson
+++ b/data/101/919/427/101919427.geojson
@@ -19,7 +19,7 @@
     "mps:longitude":-66.05817,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":12.0,
+    "mz:min_zoom":5.0,
     "name:afr_x_preferred":[
         "San Juan"
     ],
@@ -334,15 +334,16 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
-        85633729,
-        85687331,
         102191575,
+        102080441,
+        85633729,
         136253057,
-        102080441
+        85687331
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":5489690,
+        "ne:id":1159151181,
         "qs_pg:id":611081,
         "wd:id":"Q41211"
     },
@@ -363,7 +364,8 @@
         }
     ],
     "wof:id":101919427,
-    "wof:lastmodified":1582358358,
+    "wof:lastmodified":1608688179,
+    "wof:megacity":1,
     "wof:name":"San Juan",
     "wof:parent_id":102080441,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary