### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/101/918/861/101918861.geojson
+++ b/data/101/918/861/101918861.geojson
@@ -29,10 +29,19 @@
     "name:cat_x_preferred":[
         "Juncos"
     ],
+    "name:deu_x_preferred":[
+        "Juncos"
+    ],
     "name:eng_x_preferred":[
         "Juncos"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u0648\u0646\u06a9\u0648\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Juncos"
+    ],
+    "name:gle_x_preferred":[
         "Juncos"
     ],
     "name:ita_x_preferred":[
@@ -40,6 +49,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d5\u30f3\u30b3\u30b9"
+    ],
+    "name:lld_x_preferred":[
+        "Juncos"
     ],
     "name:nld_x_preferred":[
         "Juncos"
@@ -49,6 +61,9 @@
     ],
     "name:por_x_preferred":[
         "Juncos"
+    ],
+    "name:rus_x_preferred":[
+        "\u0425\u0443\u043d\u043a\u043e\u0441"
     ],
     "name:spa_x_preferred":[
         "Juncos"
@@ -137,7 +152,7 @@
         }
     ],
     "wof:id":101918861,
-    "wof:lastmodified":1566600310,
+    "wof:lastmodified":1690855878,
     "wof:name":"Juncos",
     "wof:parent_id":102080301,
     "wof:placetype":"locality",

--- a/data/101/918/865/101918865.geojson
+++ b/data/101/918/865/101918865.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:ceb_x_preferred":[
+        "Cerrillos Barrio"
+    ],
     "name:eng_x_preferred":[
         "Cerrillos"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":101918865,
-    "wof:lastmodified":1566600313,
+    "wof:lastmodified":1690855881,
     "wof:name":"Cerrillos Hoyos",
     "wof:parent_id":102080299,
     "wof:placetype":"locality",

--- a/data/101/918/867/101918867.geojson
+++ b/data/101/918/867/101918867.geojson
@@ -20,11 +20,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:azb_x_preferred":[
+        "\u0648\u0627\u06cc\u0627\u0633"
+    ],
+    "name:ceb_x_preferred":[
+        "Vayas Barrio"
+    ],
     "name:eng_x_preferred":[
+        "Vayas"
+    ],
+    "name:lld_x_preferred":[
         "Vayas"
     ],
     "name:spa_x_preferred":[
         "Vayas"
+    ],
+    "name:srp_x_preferred":[
+        "\u0412\u0430\u0458\u0430\u0441"
     ],
     "name:und_x_variant":[
         "Vavas"
@@ -79,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566600310,
+    "wof:lastmodified":1690855878,
     "wof:name":"Vayas",
     "wof:parent_id":102080299,
     "wof:placetype":"locality",

--- a/data/101/918/875/101918875.geojson
+++ b/data/101/918/875/101918875.geojson
@@ -20,10 +20,19 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:azb_x_preferred":[
+        "\u062a\u06cc\u0628\u0632"
+    ],
     "name:cat_x_preferred":[
         "Tibes"
     ],
+    "name:ceb_x_preferred":[
+        "Tibes Barrio"
+    ],
     "name:eng_x_preferred":[
+        "Tibes"
+    ],
+    "name:lld_x_preferred":[
         "Tibes"
     ],
     "name:por_x_preferred":[
@@ -31,6 +40,9 @@
     ],
     "name:spa_x_preferred":[
         "Tibes"
+    ],
+    "name:srp_x_preferred":[
+        "\u0422\u0438\u0431\u0435\u0441"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -76,7 +88,7 @@
         }
     ],
     "wof:id":101918875,
-    "wof:lastmodified":1566600309,
+    "wof:lastmodified":1690855877,
     "wof:name":"Tibes",
     "wof:parent_id":102080299,
     "wof:placetype":"locality",

--- a/data/101/918/885/101918885.geojson
+++ b/data/101/918/885/101918885.geojson
@@ -656,6 +656,9 @@
     "name:zea_x_preferred":[
         "Calzada"
     ],
+    "name:zho_x_preferred":[
+        "\u5361\u5c14\u8428\u8fbe"
+    ],
     "name:zul_x_preferred":[
         "Calzada"
     ],
@@ -703,7 +706,7 @@
         }
     ],
     "wof:id":101918885,
-    "wof:lastmodified":1566600313,
+    "wof:lastmodified":1690855881,
     "wof:name":"Calzada",
     "wof:parent_id":102080299,
     "wof:placetype":"locality",

--- a/data/101/918/891/101918891.geojson
+++ b/data/101/918/891/101918891.geojson
@@ -29,11 +29,17 @@
     "name:ara_x_variant":[
         "\u0628\u0648\u0646\u0633"
     ],
+    "name:ast_x_preferred":[
+        "Ponce"
+    ],
     "name:azb_x_preferred":[
         "\u067e\u0648\u0646\u0633"
     ],
     "name:ben_x_preferred":[
         "\u09aa\u09a8\u09cd\u09b8"
+    ],
+    "name:bpy_x_preferred":[
+        "\u09aa\u09cb\u09a8\u09b8\u09c7"
     ],
     "name:bul_x_preferred":[
         "\u041f\u043e\u043d\u0441\u0435"
@@ -65,6 +71,9 @@
     "name:epo_x_preferred":[
         "Ponce"
     ],
+    "name:eus_x_preferred":[
+        "Ponce"
+    ],
     "name:fas_x_preferred":[
         "\u067e\u0648\u0646\u0633"
     ],
@@ -72,6 +81,9 @@
         "Ponce"
     ],
     "name:fra_x_preferred":[
+        "Ponce"
+    ],
+    "name:gle_x_preferred":[
         "Ponce"
     ],
     "name:guj_x_preferred":[
@@ -110,6 +122,9 @@
     "name:lit_x_preferred":[
         "Pons\u0117"
     ],
+    "name:lld_x_preferred":[
+        "Ponce"
+    ],
     "name:mar_x_preferred":[
         "\u092a\u094b\u0928\u094d\u0938\u0947"
     ],
@@ -120,6 +135,9 @@
         "Ponce"
     ],
     "name:nld_x_preferred":[
+        "Ponce"
+    ],
+    "name:nno_x_preferred":[
         "Ponce"
     ],
     "name:nob_x_preferred":[
@@ -145,6 +163,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041f\u043e\u043d\u0441\u0435"
+    ],
+    "name:swa_x_preferred":[
+        "Ponce"
     ],
     "name:swe_x_preferred":[
         "Ponce"
@@ -343,7 +364,7 @@
         }
     ],
     "wof:id":101918891,
-    "wof:lastmodified":1636502702,
+    "wof:lastmodified":1690855881,
     "wof:name":"Ponce",
     "wof:parent_id":102080299,
     "wof:placetype":"locality",

--- a/data/101/918/893/101918893.geojson
+++ b/data/101/918/893/101918893.geojson
@@ -20,6 +20,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:ceb_x_preferred":[
+        "Marue\u00f1o Barrio"
+    ],
     "name:eng_x_preferred":[
         "Marue\u00f1o"
     ],
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":101918893,
-    "wof:lastmodified":1566600310,
+    "wof:lastmodified":1690855878,
     "wof:name":"Marue\u00f1o",
     "wof:parent_id":102080299,
     "wof:placetype":"locality",

--- a/data/101/918/899/101918899.geojson
+++ b/data/101/918/899/101918899.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u064a\u0627\u062c\u0648\u064a\u0632"
     ],
+    "name:azb_x_preferred":[
+        "\u0645\u0627\u06cc\u0627\u0642\u0648\u0632"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09af\u09bc\u09be\u0997\u09cb\u09af\u09bc\u09c7\u099c"
     ],
@@ -53,6 +56,12 @@
     "name:eng_x_preferred":[
         "Mayag\u00fcez"
     ],
+    "name:epo_x_preferred":[
+        "Mayag\u00fcez"
+    ],
+    "name:eus_x_preferred":[
+        "Mayag\u00fcez"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u06af\u0648\u0626\u0632"
     ],
@@ -60,6 +69,9 @@
         "Mayag\u00fcez"
     ],
     "name:fra_x_preferred":[
+        "Mayag\u00fcez"
+    ],
+    "name:gle_x_preferred":[
         "Mayag\u00fcez"
     ],
     "name:glg_x_preferred":[
@@ -97,6 +109,9 @@
     ],
     "name:lit_x_preferred":[
         "Majaguesas"
+    ],
+    "name:lld_x_preferred":[
+        "Mayag\u00fcez"
     ],
     "name:mar_x_preferred":[
         "\u092e\u093e\u092f\u093e\u0917\u094d\u0935\u0947\u091d"
@@ -210,7 +225,7 @@
         }
     ],
     "wof:id":101918899,
-    "wof:lastmodified":1566600313,
+    "wof:lastmodified":1690855882,
     "wof:name":"Mayag\u00fcez",
     "wof:parent_id":102080311,
     "wof:placetype":"locality",

--- a/data/101/918/905/101918905.geojson
+++ b/data/101/918/905/101918905.geojson
@@ -41,11 +41,23 @@
     "name:eng_x_preferred":[
         "Fajardo"
     ],
+    "name:epo_x_preferred":[
+        "Fajardo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0641\u0627\u062c\u0627\u0631\u062f\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Fajardo"
+    ],
+    "name:gle_x_preferred":[
         "Fajardo"
     ],
     "name:heb_x_preferred":[
         "\u05e4\u05d0\u05d7\u05e8\u05d3\u05d5"
+    ],
+    "name:hye_x_preferred":[
+        "\u0556\u0561\u056d\u0561\u0580\u0564\u0578"
     ],
     "name:ita_x_preferred":[
         "Fajardo"
@@ -55,6 +67,9 @@
     ],
     "name:kaz_x_preferred":[
         "\u0424\u0430\u0445\u0430\u0440\u0434\u043e"
+    ],
+    "name:lld_x_preferred":[
+        "Fajardo"
     ],
     "name:nld_x_preferred":[
         "Fajardo"
@@ -165,7 +180,7 @@
         }
     ],
     "wof:id":101918905,
-    "wof:lastmodified":1566600312,
+    "wof:lastmodified":1690855881,
     "wof:name":"Fajardo",
     "wof:parent_id":102080287,
     "wof:placetype":"locality",

--- a/data/101/918/909/101918909.geojson
+++ b/data/101/918/909/101918909.geojson
@@ -29,10 +29,19 @@
     "name:ceb_x_preferred":[
         "Comer\u00edo"
     ],
+    "name:deu_x_preferred":[
+        "Comer\u00edo"
+    ],
     "name:eng_x_preferred":[
         "Comer\u00edo"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0645\u0631\u06cc\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Comer\u00edo"
+    ],
+    "name:gle_x_preferred":[
         "Comer\u00edo"
     ],
     "name:ita_x_preferred":[
@@ -46,6 +55,9 @@
     ],
     "name:por_x_preferred":[
         "Comer\u00edo"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u043c\u0435\u0440\u0438\u043e"
     ],
     "name:spa_x_preferred":[
         "Comer\u00edo"
@@ -111,7 +123,7 @@
         }
     ],
     "wof:id":101918909,
-    "wof:lastmodified":1566600308,
+    "wof:lastmodified":1690855876,
     "wof:name":"Comer\u00edo",
     "wof:parent_id":102080291,
     "wof:placetype":"locality",

--- a/data/101/918/913/101918913.geojson
+++ b/data/101/918/913/101918913.geojson
@@ -32,10 +32,19 @@
     "name:ceb_x_preferred":[
         "Patillas"
     ],
+    "name:deu_x_preferred":[
+        "Patillas"
+    ],
     "name:eng_x_preferred":[
         "Patillas"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0627\u062a\u06cc\u0644\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Patillas"
+    ],
+    "name:gle_x_preferred":[
         "Patillas"
     ],
     "name:hbs_x_preferred":[
@@ -47,11 +56,17 @@
     "name:jpn_x_preferred":[
         "\u30d1\u30c6\u30a3\u30ea\u30e3\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Patillas"
+    ],
     "name:nld_x_preferred":[
         "Patillas"
     ],
     "name:por_x_preferred":[
         "Patillas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0430\u0442\u0438\u043b\u044c\u044f\u0441"
     ],
     "name:spa_x_preferred":[
         "Patillas"
@@ -144,7 +159,7 @@
         }
     ],
     "wof:id":101918913,
-    "wof:lastmodified":1566600311,
+    "wof:lastmodified":1690855879,
     "wof:name":"Patillas",
     "wof:parent_id":102080445,
     "wof:placetype":"locality",

--- a/data/101/918/917/101918917.geojson
+++ b/data/101/918/917/101918917.geojson
@@ -29,7 +29,13 @@
     "name:eng_x_preferred":[
         "Lamboglia"
     ],
+    "name:lld_x_preferred":[
+        "Lamboglia"
+    ],
     "name:nld_x_preferred":[
+        "Lamboglia"
+    ],
+    "name:spa_x_preferred":[
         "Lamboglia"
     ],
     "name:srp_x_preferred":[
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":101918917,
-    "wof:lastmodified":1566600314,
+    "wof:lastmodified":1690855883,
     "wof:name":"Lamboglia",
     "wof:parent_id":102080445,
     "wof:placetype":"locality",

--- a/data/101/918/919/101918919.geojson
+++ b/data/101/918/919/101918919.geojson
@@ -38,7 +38,13 @@
     "name:eng_x_preferred":[
         "Luquillo"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0648\u06a9\u06cc\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Luquillo"
+    ],
+    "name:gle_x_preferred":[
         "Luquillo"
     ],
     "name:ita_x_preferred":[
@@ -46,6 +52,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30eb\u30ad\u30ea\u30e7"
+    ],
+    "name:lld_x_preferred":[
+        "Luquillo"
     ],
     "name:nld_x_preferred":[
         "Luquillo"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":101918919,
-    "wof:lastmodified":1566600314,
+    "wof:lastmodified":1690855882,
     "wof:name":"Luquillo",
     "wof:parent_id":102080339,
     "wof:placetype":"locality",

--- a/data/101/918/921/101918921.geojson
+++ b/data/101/918/921/101918921.geojson
@@ -50,6 +50,9 @@
     "name:cat_x_preferred":[
         "Ramos"
     ],
+    "name:ceb_x_preferred":[
+        "Ramos"
+    ],
     "name:ces_x_preferred":[
         "Ramos"
     ],
@@ -119,10 +122,16 @@
     "name:ile_x_preferred":[
         "Ramos"
     ],
+    "name:ilo_x_preferred":[
+        "Ramos"
+    ],
     "name:ina_x_preferred":[
         "Ramos"
     ],
     "name:ind_x_preferred":[
+        "Ramos"
+    ],
+    "name:isl_x_preferred":[
         "Ramos"
     ],
     "name:ita_x_preferred":[
@@ -227,16 +236,28 @@
     "name:slk_x_preferred":[
         "Ramos"
     ],
+    "name:slv_x_preferred":[
+        "Ramos"
+    ],
     "name:spa_x_preferred":[
+        "Ramos"
+    ],
+    "name:sqi_x_preferred":[
         "Ramos"
     ],
     "name:srd_x_preferred":[
         "Ramos"
     ],
+    "name:srp_x_preferred":[
+        "\u0420\u0430\u043c\u043e\u0441"
+    ],
     "name:swa_x_preferred":[
         "Ramos"
     ],
     "name:swe_x_preferred":[
+        "Ramos"
+    ],
+    "name:tgl_x_preferred":[
         "Ramos"
     ],
     "name:tur_x_preferred":[
@@ -258,6 +279,9 @@
         "Ramos"
     ],
     "name:vol_x_preferred":[
+        "Ramos"
+    ],
+    "name:war_x_preferred":[
         "Ramos"
     ],
     "name:wln_x_preferred":[
@@ -337,7 +361,7 @@
         }
     ],
     "wof:id":101918921,
-    "wof:lastmodified":1566600314,
+    "wof:lastmodified":1690855882,
     "wof:name":"Ramos",
     "wof:parent_id":102080339,
     "wof:placetype":"locality",

--- a/data/101/918/923/101918923.geojson
+++ b/data/101/918/923/101918923.geojson
@@ -20,6 +20,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:azb_x_preferred":[
+        "\u062a\u0648\u0627 \u0622\u0644\u062a\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u099f\u09f1\u09be \u0986\u09b2\u099f\u09be"
     ],
@@ -29,10 +32,19 @@
     "name:ceb_x_preferred":[
         "Toa Alta"
     ],
+    "name:deu_x_preferred":[
+        "Toa Alta"
+    ],
     "name:eng_x_preferred":[
         "Toa Alta"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0648\u0622 \u0622\u0644\u062a\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Toa Alta"
+    ],
+    "name:gle_x_preferred":[
         "Toa Alta"
     ],
     "name:ita_x_preferred":[
@@ -41,11 +53,17 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30a2\u30fb\u30a2\u30eb\u30bf"
     ],
+    "name:lld_x_preferred":[
+        "Toa Alta"
+    ],
     "name:nld_x_preferred":[
         "Toa Alta"
     ],
     "name:por_x_preferred":[
         "Toa Alta"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u043e\u0430-\u0410\u043b\u044c\u0442\u0430"
     ],
     "name:scn_x_preferred":[
         "Toa Alta"
@@ -118,7 +136,7 @@
         }
     ],
     "wof:id":101918923,
-    "wof:lastmodified":1566600310,
+    "wof:lastmodified":1690855878,
     "wof:name":"Toa Alta",
     "wof:parent_id":102080359,
     "wof:placetype":"locality",

--- a/data/101/918/931/101918931.geojson
+++ b/data/101/918/931/101918931.geojson
@@ -23,10 +23,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Playa Fortuna"
+    ],
     "name:eng_x_preferred":[
         "Playa Fortuna"
     ],
     "name:ita_x_preferred":[
+        "Playa Fortuna"
+    ],
+    "name:lld_x_preferred":[
         "Playa Fortuna"
     ],
     "name:nld_x_preferred":[
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":101918931,
-    "wof:lastmodified":1566600308,
+    "wof:lastmodified":1690855876,
     "wof:name":"Playa Fortuna",
     "wof:parent_id":102080339,
     "wof:placetype":"locality",

--- a/data/101/918/935/101918935.geojson
+++ b/data/101/918/935/101918935.geojson
@@ -44,10 +44,19 @@
     "name:epo_x_preferred":[
         "Rivero Granda"
     ],
+    "name:fas_x_preferred":[
+        "\u0631\u06cc\u0648 \u06af\u0631\u0627\u0646\u062f"
+    ],
     "name:fra_x_preferred":[
         "R\u00edo Grande"
     ],
+    "name:gle_x_preferred":[
+        "R\u00edo Grande"
+    ],
     "name:hbs_x_preferred":[
+        "R\u00edo Grande"
+    ],
+    "name:hun_x_preferred":[
         "R\u00edo Grande"
     ],
     "name:ita_x_preferred":[
@@ -59,11 +68,17 @@
     "name:nld_x_preferred":[
         "R\u00edo Grande"
     ],
+    "name:nob_x_preferred":[
+        "R\u00edo Grande"
+    ],
     "name:pol_x_preferred":[
         "R\u00edo Grande"
     ],
     "name:por_x_preferred":[
         "R\u00edo Grande"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u0438\u043e-\u0413\u0440\u0430\u043d\u0434\u0435"
     ],
     "name:spa_x_preferred":[
         "R\u00edo Grande"
@@ -150,7 +165,7 @@
         }
     ],
     "wof:id":101918935,
-    "wof:lastmodified":1566600311,
+    "wof:lastmodified":1690855880,
     "wof:name":"Galateo",
     "wof:parent_id":102080359,
     "wof:placetype":"locality",

--- a/data/101/918/937/101918937.geojson
+++ b/data/101/918/937/101918937.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0643\u0627\u0645\u0648\u064a"
+    ],
     "name:bpy_x_preferred":[
         "\u0995\u09be\u09ae\u09c1\u09af\u09bc"
     ],
@@ -30,10 +33,22 @@
     "name:ceb_x_preferred":[
         "Camuy"
     ],
+    "name:deu_x_preferred":[
+        "Camuy"
+    ],
     "name:eng_x_preferred":[
         "Camuy"
     ],
+    "name:epo_x_preferred":[
+        "Camuy"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0645\u0648\u06cc"
+    ],
     "name:fra_x_preferred":[
+        "Camuy"
+    ],
+    "name:gle_x_preferred":[
         "Camuy"
     ],
     "name:hbs_x_preferred":[
@@ -45,11 +60,17 @@
     "name:jpn_x_preferred":[
         "\u30ab\u30e0\u30a4"
     ],
+    "name:lld_x_preferred":[
+        "Camuy"
+    ],
     "name:nld_x_preferred":[
         "Camuy"
     ],
     "name:por_x_preferred":[
         "Camuy"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u043c\u0443\u0439"
     ],
     "name:spa_x_preferred":[
         "Camuy"
@@ -119,7 +140,7 @@
         }
     ],
     "wof:id":101918937,
-    "wof:lastmodified":1566600309,
+    "wof:lastmodified":1690855876,
     "wof:name":"Camuy",
     "wof:parent_id":102080293,
     "wof:placetype":"locality",

--- a/data/101/918/947/101918947.geojson
+++ b/data/101/918/947/101918947.geojson
@@ -32,17 +32,32 @@
     "name:ceb_x_preferred":[
         "Coamo Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Coamo"
+    ],
     "name:eng_x_preferred":[
         "Coamo"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u0622\u0645\u0648"
+    ],
     "name:fra_x_preferred":[
         "Coamo"
+    ],
+    "name:gle_x_preferred":[
+        "Coamo"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d5\u05d0\u05de\u05d5"
     ],
     "name:ita_x_preferred":[
         "Coamo"
     ],
     "name:jpn_x_preferred":[
         "\u30b3\u30a2\u30e2"
+    ],
+    "name:lld_x_preferred":[
+        "Coamo"
     ],
     "name:nld_x_preferred":[
         "Coamo"
@@ -76,6 +91,9 @@
     ],
     "name:war_x_preferred":[
         "Coamo"
+    ],
+    "name:wuu_x_preferred":[
+        "\u79d1\u963f\u83ab"
     ],
     "name:zho_x_preferred":[
         "\u79d1\u963f\u83ab"
@@ -146,7 +164,7 @@
         }
     ],
     "wof:id":101918947,
-    "wof:lastmodified":1566600311,
+    "wof:lastmodified":1690855879,
     "wof:name":"Coamo",
     "wof:parent_id":102080279,
     "wof:placetype":"locality",

--- a/data/101/918/955/101918955.geojson
+++ b/data/101/918/955/101918955.geojson
@@ -29,10 +29,22 @@
     "name:ceb_x_preferred":[
         "Cata\u00f1o Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Cata\u00f1o"
+    ],
     "name:eng_x_preferred":[
         "Cata\u00f1o"
     ],
+    "name:epo_x_preferred":[
+        "Cata\u00f1o"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u062a\u0627\u0626\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Cata\u00f1o"
+    ],
+    "name:gle_x_preferred":[
         "Cata\u00f1o"
     ],
     "name:ita_x_preferred":[
@@ -50,6 +62,9 @@
     "name:por_x_preferred":[
         "Cata\u00f1o"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u0442\u0430\u043d\u044c\u043e"
+    ],
     "name:sco_x_preferred":[
         "Cata\u00f1o"
     ],
@@ -58,6 +73,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0442\u0430\u045a\u043e"
+    ],
+    "name:swe_x_preferred":[
+        "Cata\u00f1o"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u0442\u0430\u043d\u044c\u0439\u043e"
@@ -92,11 +110,11 @@
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
-        102191575,
-        102080289,
         85633729,
+        85687331,
+        102191575,
         136253057,
-        85687331
+        102080289
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,7 +138,7 @@
         }
     ],
     "wof:id":101918955,
-    "wof:lastmodified":1607986515,
+    "wof:lastmodified":1690855877,
     "wof:name":"Cata\u00f1o",
     "wof:parent_id":102080289,
     "wof:placetype":"locality",

--- a/data/101/918/957/101918957.geojson
+++ b/data/101/918/957/101918957.geojson
@@ -32,13 +32,22 @@
     "name:ceb_x_preferred":[
         "San Lorenzo Municipio"
     ],
+    "name:deu_x_preferred":[
+        "San Lorenzo"
+    ],
     "name:eng_x_preferred":[
         "San Lorenzo"
     ],
     "name:epo_x_preferred":[
         "Sankt-La\u016drenco"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0627\u0646 \u0644\u0648\u0631\u0646\u0632\u0648"
+    ],
     "name:fra_x_preferred":[
+        "San Lorenzo"
+    ],
+    "name:gle_x_preferred":[
         "San Lorenzo"
     ],
     "name:ita_x_preferred":[
@@ -46,6 +55,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30fb\u30ed\u30ec\u30f3\u30bd"
+    ],
+    "name:lld_x_preferred":[
+        "San Lorenzo"
     ],
     "name:nld_x_preferred":[
         "San Lorenzo"
@@ -55,6 +67,9 @@
     ],
     "name:por_x_preferred":[
         "San Lorenzo"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u043d-\u041b\u043e\u0440\u0435\u043d\u0441\u043e"
     ],
     "name:spa_x_preferred":[
         "San Lorenzo"
@@ -156,7 +171,7 @@
         }
     ],
     "wof:id":101918957,
-    "wof:lastmodified":1636502701,
+    "wof:lastmodified":1690855880,
     "wof:name":"San Lorenzo",
     "wof:parent_id":102080309,
     "wof:placetype":"locality",

--- a/data/101/918/963/101918963.geojson
+++ b/data/101/918/963/101918963.geojson
@@ -29,6 +29,9 @@
     "name:bpy_x_preferred":[
         "\u09b2\u09be\u09b0\u09c7\u09b8"
     ],
+    "name:bul_x_preferred":[
+        "\u041b\u0430\u0440\u0435\u0441"
+    ],
     "name:cat_x_preferred":[
         "Lares"
     ],
@@ -56,6 +59,9 @@
     "name:fra_x_preferred":[
         "Lares"
     ],
+    "name:gle_x_preferred":[
+        "Lares"
+    ],
     "name:hbs_x_preferred":[
         "Lares"
     ],
@@ -68,7 +74,13 @@
     "name:jpn_x_preferred":[
         "\u30e9\u30ec\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Lares"
+    ],
     "name:nld_x_preferred":[
+        "Lares"
+    ],
+    "name:pol_x_preferred":[
         "Lares"
     ],
     "name:por_x_preferred":[
@@ -172,7 +184,7 @@
         }
     ],
     "wof:id":101918963,
-    "wof:lastmodified":1566600309,
+    "wof:lastmodified":1690855877,
     "wof:name":"Lares",
     "wof:parent_id":102080379,
     "wof:placetype":"locality",

--- a/data/101/918/965/101918965.geojson
+++ b/data/101/918/965/101918965.geojson
@@ -23,10 +23,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":8.0,
+    "name:bpy_x_preferred":[
+        "\u099f\u09cd\u09b0\u09c1\u099c\u09bf\u09b2\u09cd\u09b2\u09cb \u0986\u09b2\u099f\u09cb"
+    ],
     "name:cat_x_preferred":[
         "Trujillo Alto"
     ],
     "name:ceb_x_preferred":[
+        "Trujillo Alto"
+    ],
+    "name:deu_x_preferred":[
         "Trujillo Alto"
     ],
     "name:eng_x_preferred":[
@@ -44,6 +50,9 @@
     "name:fra_x_preferred":[
         "Trujillo Alto"
     ],
+    "name:gle_x_preferred":[
+        "Trujillo Alto"
+    ],
     "name:ita_x_preferred":[
         "Trujillo Alto"
     ],
@@ -52,6 +61,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud2b8\ub8e8\ud788\uc694\uc54c\ud1a0"
+    ],
+    "name:lld_x_preferred":[
+        "Trujillo Alto"
     ],
     "name:nld_x_preferred":[
         "Trujillo Alto"
@@ -73,6 +85,9 @@
     ],
     "name:srp_x_preferred":[
         "\u0422\u0440\u0443\u0445\u0438\u0459\u043e \u0410\u043b\u0442\u043e"
+    ],
+    "name:szl_x_preferred":[
+        "Trujillo Alto"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0440\u0443\u0445\u0456\u043b\u044c\u0439\u043e-\u0410\u043b\u044c\u0442\u043e"
@@ -155,7 +170,7 @@
         }
     ],
     "wof:id":101918965,
-    "wof:lastmodified":1566600308,
+    "wof:lastmodified":1690855876,
     "wof:name":"Trujillo Alto",
     "wof:parent_id":102080361,
     "wof:placetype":"locality",

--- a/data/101/918/971/101918971.geojson
+++ b/data/101/918/971/101918971.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:azb_x_preferred":[
+        "\u06cc\u0627\u0628\u0648\u06a9\u0648\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u09af\u09bc\u09be\u09ac\u09c1\u0995\u09cb\u09af\u09bc\u09be"
     ],
@@ -30,13 +33,25 @@
     "name:ceb_x_preferred":[
         "Yabucoa"
     ],
+    "name:deu_x_preferred":[
+        "Yabucoa"
+    ],
     "name:eng_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:epo_x_preferred":[
         "Yabucoa"
     ],
     "name:est_x_preferred":[
         "Yabucoa"
     ],
+    "name:fas_x_preferred":[
+        "\u06cc\u0627\u0628\u0648\u0633\u0627\u0622"
+    ],
     "name:fra_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:gle_x_preferred":[
         "Yabucoa"
     ],
     "name:hbs_x_preferred":[
@@ -48,8 +63,20 @@
     "name:jpn_x_preferred":[
         "\u30e4\u30d6\u30b3\u30a2"
     ],
+    "name:lld_x_preferred":[
+        "Yabucoa"
+    ],
     "name:nld_x_preferred":[
         "Yabucoa"
+    ],
+    "name:pol_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:por_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:rus_x_preferred":[
+        "\u042f\u0431\u0443\u043a\u043e\u0430"
     ],
     "name:scn_x_preferred":[
         "Yabucoa"
@@ -128,7 +155,7 @@
         }
     ],
     "wof:id":101918971,
-    "wof:lastmodified":1566600311,
+    "wof:lastmodified":1690855879,
     "wof:name":"Yabucoa",
     "wof:parent_id":102080371,
     "wof:placetype":"locality",

--- a/data/101/918/985/101918985.geojson
+++ b/data/101/918/985/101918985.geojson
@@ -32,6 +32,12 @@
     "name:cat_x_preferred":[
         "Santa Isabel"
     ],
+    "name:ceb_x_preferred":[
+        "Santa Isabel Municipio"
+    ],
+    "name:deu_x_preferred":[
+        "Santa Isabel"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03ac\u03bd\u03c4\u03b1 \u0399\u03b6\u03b1\u03bc\u03c0\u03ad\u03bb"
     ],
@@ -41,7 +47,13 @@
     "name:epo_x_preferred":[
         "Sankta Izabela"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0627\u0646\u062a\u0627 \u0627\u06cc\u0632\u0627\u0628\u0644"
+    ],
     "name:fra_x_preferred":[
+        "Santa Isabel"
+    ],
+    "name:gle_x_preferred":[
         "Santa Isabel"
     ],
     "name:heb_x_preferred":[
@@ -59,11 +71,20 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30bf\u30fb\u30a4\u30b5\u30d9\u30eb"
     ],
+    "name:lld_x_preferred":[
+        "Santa Isabel"
+    ],
     "name:nld_x_preferred":[
+        "Santa Isabel"
+    ],
+    "name:pol_x_preferred":[
         "Santa Isabel"
     ],
     "name:por_x_preferred":[
         "Santa Isabel"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u043d\u0442\u0430-\u0418\u0441\u0430\u0431\u0435\u043b\u044c"
     ],
     "name:spa_x_preferred":[
         "Santa Isabel"
@@ -155,7 +176,7 @@
         }
     ],
     "wof:id":101918985,
-    "wof:lastmodified":1636502701,
+    "wof:lastmodified":1690855879,
     "wof:name":"Santa Isabel",
     "wof:parent_id":102080335,
     "wof:placetype":"locality",

--- a/data/101/918/995/101918995.geojson
+++ b/data/101/918/995/101918995.geojson
@@ -35,7 +35,13 @@
     "name:eng_x_preferred":[
         "Rinc\u00f3n"
     ],
+    "name:fas_x_preferred":[
+        "\u0631\u06cc\u0646\u0633\u0648\u0646"
+    ],
     "name:fra_x_preferred":[
+        "Rinc\u00f3n"
+    ],
+    "name:gle_x_preferred":[
         "Rinc\u00f3n"
     ],
     "name:hun_x_preferred":[
@@ -50,8 +56,14 @@
     "name:nld_x_preferred":[
         "Rinc\u00f3n"
     ],
+    "name:nob_x_preferred":[
+        "Rinc\u00f3n"
+    ],
     "name:por_x_preferred":[
         "Rinc\u00f3n"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u0438\u043d\u043a\u043e\u043d\u0430"
     ],
     "name:spa_x_preferred":[
         "Rinc\u00f3n"
@@ -117,7 +129,7 @@
         }
     ],
     "wof:id":101918995,
-    "wof:lastmodified":1566600311,
+    "wof:lastmodified":1690855880,
     "wof:name":"Rinc\u00f3n",
     "wof:parent_id":102080307,
     "wof:placetype":"locality",

--- a/data/101/918/999/101918999.geojson
+++ b/data/101/918/999/101918999.geojson
@@ -23,10 +23,25 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:azb_x_preferred":[
+        "\u0627\u06cc\u0633\u062a\u0644\u0627"
+    ],
+    "name:ceb_x_preferred":[
+        "Stella"
+    ],
     "name:eng_x_preferred":[
         "Stella"
     ],
+    "name:lld_x_preferred":[
+        "Stella"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d38\u0d4d\u0d31\u0d4d\u0d31\u0d46\u0d32\u0d4d\u0d32"
+    ],
     "name:nld_x_preferred":[
+        "Stella"
+    ],
+    "name:spa_x_preferred":[
         "Stella"
     ],
     "name:srp_x_preferred":[
@@ -102,7 +117,7 @@
         }
     ],
     "wof:id":101918999,
-    "wof:lastmodified":1566600309,
+    "wof:lastmodified":1690855877,
     "wof:name":"Stella",
     "wof:parent_id":102080307,
     "wof:placetype":"locality",

--- a/data/101/919/003/101919003.geojson
+++ b/data/101/919/003/101919003.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
     "name:bpy_x_preferred":[
         "\u09b8\u09be\u09a8 \u09b8\u09c7\u09ac\u09be\u09b8\u09cd\u09a4\u09bf\u09a8"
     ],
@@ -32,13 +35,22 @@
     "name:ceb_x_preferred":[
         "San Sebasti\u00e1n Municipio"
     ],
+    "name:deu_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
     "name:eng_x_preferred":[
         "San Sebasti\u00e1n"
     ],
     "name:epo_x_preferred":[
         "Sankt-Sebastiano"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0646 \u0633\u0628\u0627\u0633\u062a\u06cc\u0646"
+    ],
     "name:fra_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
+    "name:gle_x_preferred":[
         "San Sebasti\u00e1n"
     ],
     "name:hbs_x_preferred":[
@@ -58,6 +70,9 @@
     ],
     "name:por_x_preferred":[
         "San Sebasti\u00e1n"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u043d-\u0421\u0435\u0431\u0430\u0441\u0442\u044c\u044f\u043d"
     ],
     "name:spa_x_preferred":[
         "San Sebasti\u00e1n"
@@ -144,7 +159,7 @@
         }
     ],
     "wof:id":101919003,
-    "wof:lastmodified":1566600332,
+    "wof:lastmodified":1690855902,
     "wof:name":"Hato Arriba",
     "wof:parent_id":102080411,
     "wof:placetype":"locality",

--- a/data/101/919/005/101919005.geojson
+++ b/data/101/919/005/101919005.geojson
@@ -20,6 +20,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:ast_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
     "name:bpy_x_preferred":[
         "\u09b8\u09be\u09a8 \u09b8\u09c7\u09ac\u09be\u09b8\u09cd\u09a4\u09bf\u09a8"
     ],
@@ -29,13 +32,22 @@
     "name:ceb_x_preferred":[
         "San Sebasti\u00e1n Municipio"
     ],
+    "name:deu_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
     "name:eng_x_preferred":[
         "San Sebasti\u00e1n"
     ],
     "name:epo_x_preferred":[
         "Sankt-Sebastiano"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0646 \u0633\u0628\u0627\u0633\u062a\u06cc\u0646"
+    ],
     "name:fra_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
+    "name:gle_x_preferred":[
         "San Sebasti\u00e1n"
     ],
     "name:ita_x_preferred":[
@@ -52,6 +64,9 @@
     ],
     "name:por_x_preferred":[
         "San Sebasti\u00e1n"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u043d-\u0421\u0435\u0431\u0430\u0441\u0442\u044c\u044f\u043d"
     ],
     "name:spa_x_preferred":[
         "San Sebasti\u00e1n"
@@ -117,7 +132,7 @@
         }
     ],
     "wof:id":101919005,
-    "wof:lastmodified":1566600333,
+    "wof:lastmodified":1690855905,
     "wof:name":"San Sebasti\u00e1n",
     "wof:parent_id":102080411,
     "wof:placetype":"locality",

--- a/data/101/919/007/101919007.geojson
+++ b/data/101/919/007/101919007.geojson
@@ -26,10 +26,16 @@
     "name:cat_x_preferred":[
         "Santa Clara"
     ],
+    "name:ceb_x_preferred":[
+        "Santa Clara"
+    ],
     "name:eng_x_preferred":[
         "Santa Clara"
     ],
     "name:glg_x_preferred":[
+        "Santa Clara"
+    ],
+    "name:lld_x_preferred":[
         "Santa Clara"
     ],
     "name:nld_x_preferred":[
@@ -111,7 +117,7 @@
         }
     ],
     "wof:id":101919007,
-    "wof:lastmodified":1566600321,
+    "wof:lastmodified":1690855890,
     "wof:name":"Santa Clara",
     "wof:parent_id":102080321,
     "wof:placetype":"locality",

--- a/data/101/919/009/101919009.geojson
+++ b/data/101/919/009/101919009.geojson
@@ -32,6 +32,12 @@
     "name:ceb_x_preferred":[
         "Aguas Buenas"
     ],
+    "name:deu_x_preferred":[
+        "Aguas Buenas"
+    ],
+    "name:ell_x_preferred":[
+        "\u0386\u03b3\u03bf\u03c5\u03b1\u03c2 \u0392\u03bf\u03c5\u03ad\u03bd\u03b1\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Aguas Buenas"
     ],
@@ -47,6 +53,9 @@
     "name:fra_x_preferred":[
         "Aguas Buenas"
     ],
+    "name:gle_x_preferred":[
+        "Aguas Buenas"
+    ],
     "name:hye_x_preferred":[
         "\u0531\u0563\u0578\u0582\u0561\u057d \u0532\u0578\u0582\u0565\u0576\u0561\u057d"
     ],
@@ -56,11 +65,17 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30b0\u30a2\u30b9\u30fb\u30d6\u30a8\u30ca\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Aguas Buenas"
+    ],
     "name:nld_x_preferred":[
         "Aguas Buenas"
     ],
     "name:por_x_preferred":[
         "Aguas Buenas"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0433\u0443\u0430\u0441-\u0411\u0443\u044d\u043d\u0430\u0441"
     ],
     "name:scn_x_preferred":[
         "Aguas Buenas"
@@ -152,7 +167,7 @@
         }
     ],
     "wof:id":101919009,
-    "wof:lastmodified":1566600321,
+    "wof:lastmodified":1690855890,
     "wof:name":"Aguas Buenas",
     "wof:parent_id":102080321,
     "wof:placetype":"locality",

--- a/data/101/919/011/101919011.geojson
+++ b/data/101/919/011/101919011.geojson
@@ -26,6 +26,9 @@
     "name:afr_x_preferred":[
         "San Antonio"
     ],
+    "name:aka_x_preferred":[
+        "San Antonio"
+    ],
     "name:amh_x_preferred":[
         "\u1233\u1295 \u12a0\u1295\u1276\u1292\u12ee"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:arg_x_preferred":[
         "San Antonio"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u0627\u0646\u0637\u0648\u0646\u064a\u0648"
     ],
     "name:ast_x_preferred":[
         "San Antonio"
@@ -74,10 +80,16 @@
     "name:che_x_preferred":[
         "\u0421\u0430\u043d-\u0410\u043d\u0442\u043e\u043d\u0438\u043e"
     ],
+    "name:ckb_x_preferred":[
+        "\u0633\u0627\u0646 \u0626\u06d5\u0646\u062a\u06c6\u0646\u06cc\u06c6"
+    ],
     "name:cor_x_preferred":[
         "San Antonio"
     ],
     "name:cym_x_preferred":[
+        "San Antonio"
+    ],
+    "name:dag_x_preferred":[
         "San Antonio"
     ],
     "name:dan_x_preferred":[
@@ -134,6 +146,9 @@
     "name:glg_x_preferred":[
         "San Antonio"
     ],
+    "name:grn_x_preferred":[
+        "San Antonio"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8 \u0a8f\u0aa8\u0acd\u0a9f\u0acb\u0aa8\u0abf\u0aaf\u0acb"
     ],
@@ -158,6 +173,12 @@
     "name:hye_x_preferred":[
         "\u054d\u0561\u0576 \u0531\u0576\u057f\u0578\u0576\u056b\u0578"
     ],
+    "name:ido_x_preferred":[
+        "San Antonio"
+    ],
+    "name:ile_x_preferred":[
+        "San Antonio"
+    ],
     "name:ilo_x_preferred":[
         "San Antonio"
     ],
@@ -179,6 +200,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30a2\u30f3\u30c8\u30cb\u30aa"
     ],
+    "name:jpn_x_variant":[
+        "\u30b5\u30f3\u30fb\u30a2\u30f3\u30c8\u30cb\u30aa"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0ccd\u0caf\u0cbe\u0ca8\u0ccd \u0c86\u0c82\u0c9f\u0ccb\u0ca8\u0cbf\u0caf\u0ccb"
     ],
@@ -194,11 +218,17 @@
     "name:kor_x_preferred":[
         "\uc0cc\uc548\ud1a0\ub2c8\uc624"
     ],
+    "name:kur_x_preferred":[
+        "San Antonio"
+    ],
     "name:lad_x_preferred":[
         "San Antonio"
     ],
     "name:lat_x_preferred":[
         "Sanctus Antonius"
+    ],
+    "name:lat_x_variant":[
+        "Antoniopolis"
     ],
     "name:lav_x_preferred":[
         "Sanantonio"
@@ -211,6 +241,9 @@
     ],
     "name:lit_x_preferred":[
         "San Antonijas"
+    ],
+    "name:lld_x_preferred":[
+        "San Antonio"
     ],
     "name:ltz_x_preferred":[
         "San Antonio"
@@ -236,11 +269,17 @@
     "name:msa_x_preferred":[
         "San Antonio"
     ],
+    "name:mya_x_preferred":[
+        "\u1006\u1014\u103a \u1021\u1014\u103a\u1010\u102d\u102f\u1014\u102e\u101a\u102d\u102f"
+    ],
     "name:nah_x_preferred":[
         "San Antonio"
     ],
     "name:nan_x_preferred":[
         "San Antonio"
+    ],
+    "name:nav_x_preferred":[
+        "Kin Hal\u00e1n\u00edtah"
     ],
     "name:nep_x_preferred":[
         "\u0938\u093e\u0928 \u0906\u0928\u094d\u091f\u094b\u0928\u093f\u092f\u094b"
@@ -300,6 +339,9 @@
         "San Antonio"
     ],
     "name:slv_x_preferred":[
+        "San Antonio"
+    ],
+    "name:smn_x_preferred":[
         "San Antonio"
     ],
     "name:som_x_preferred":[
@@ -379,6 +421,9 @@
     ],
     "name:war_x_preferred":[
         "San Antonio"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5723\u5b89\u4e1c\u5c3c\u5965"
     ],
     "name:xmf_x_preferred":[
         "\u10e1\u10d0\u10dc-\u10d0\u10dc\u10d7\u10dd\u10dc\u10d8\u10dd"
@@ -464,7 +509,7 @@
         }
     ],
     "wof:id":101919011,
-    "wof:lastmodified":1566600330,
+    "wof:lastmodified":1690855900,
     "wof:name":"San Antonio",
     "wof:parent_id":102080275,
     "wof:placetype":"locality",

--- a/data/101/919/017/101919017.geojson
+++ b/data/101/919/017/101919017.geojson
@@ -23,6 +23,15 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ast_x_preferred":[
+        "Aguadilla"
+    ],
+    "name:azb_x_preferred":[
+        "\u0622\u0642\u0648\u0627\u062f\u06cc\u0644\u0627"
+    ],
+    "name:aze_x_preferred":[
+        "Aquadilya"
+    ],
     "name:bpy_x_preferred":[
         "\u0986\u0997\u09c1\u09f1\u09be\u09a1\u09bf\u09b2\u09be"
     ],
@@ -42,6 +51,9 @@
         "\u0391\u03b3\u03bf\u03c5\u03b1\u03b4\u03af\u03b3\u03b9\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Aguadilla"
+    ],
+    "name:epo_x_preferred":[
         "Aguadilla"
     ],
     "name:fas_x_preferred":[
@@ -64,6 +76,12 @@
     ],
     "name:kaz_x_preferred":[
         "\u0410\u0433\u0443\u0430\u0434\u0438\u043b\u044c\u044f"
+    ],
+    "name:kor_x_preferred":[
+        "\uc544\uacfc\ub514\uc57c"
+    ],
+    "name:lld_x_preferred":[
+        "Aguadilla"
     ],
     "name:nld_x_preferred":[
         "Aguadilla"
@@ -174,7 +192,7 @@
         }
     ],
     "wof:id":101919017,
-    "wof:lastmodified":1566600331,
+    "wof:lastmodified":1690855901,
     "wof:name":"Aguadilla",
     "wof:parent_id":102080275,
     "wof:placetype":"locality",

--- a/data/101/919/019/101919019.geojson
+++ b/data/101/919/019/101919019.geojson
@@ -26,6 +26,9 @@
     "name:cat_x_preferred":[
         "Rafael Hern\u00e1ndez"
     ],
+    "name:ceb_x_preferred":[
+        "Rafael Hernandez"
+    ],
     "name:eng_x_preferred":[
         "Rafael Hern\u00e1ndez"
     ],
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":101919019,
-    "wof:lastmodified":1566600331,
+    "wof:lastmodified":1690855901,
     "wof:name":"Rafael Hern\u00e1ndez",
     "wof:parent_id":102080275,
     "wof:placetype":"locality",

--- a/data/101/919/021/101919021.geojson
+++ b/data/101/919/021/101919021.geojson
@@ -26,6 +26,9 @@
     "name:eng_x_preferred":[
         "Cayuco"
     ],
+    "name:fra_x_preferred":[
+        "Cayuco"
+    ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
     "qs:a1_lc":"72",
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101919021,
-    "wof:lastmodified":1566600332,
+    "wof:lastmodified":1690855901,
     "wof:name":"Cayuco",
     "wof:parent_id":102080433,
     "wof:placetype":"locality",

--- a/data/101/919/023/101919023.geojson
+++ b/data/101/919/023/101919023.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:azb_x_preferred":[
+        "\u0627\u0648\u062a\u0648\u0627\u062f\u0648"
+    ],
     "name:bpy_x_preferred":[
         "\u0989\u099f\u09c1\u09f1\u09be\u09a6\u09be"
     ],
@@ -32,20 +35,38 @@
     "name:ceb_x_preferred":[
         "Utuado"
     ],
+    "name:deu_x_preferred":[
+        "Utuado"
+    ],
     "name:eng_x_preferred":[
         "Utuado"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0648\u062a\u0627\u062f\u0648"
     ],
     "name:fra_x_preferred":[
         "Utuado"
     ],
+    "name:gle_x_preferred":[
+        "Utuado"
+    ],
     "name:hbs_x_preferred":[
         "Utuado"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d5\u05d8\u05d5\u05d0\u05d3\u05d5"
     ],
     "name:ita_x_preferred":[
         "Utuado"
     ],
     "name:jpn_x_preferred":[
         "\u30a6\u30c8\u30a5\u30a2\u30fc\u30c9"
+    ],
+    "name:kor_x_preferred":[
+        "\uc6b0\ud22c\uc544\ub3c4"
+    ],
+    "name:lld_x_preferred":[
+        "Utuado"
     ],
     "name:nld_x_preferred":[
         "Utuado"
@@ -153,7 +174,7 @@
         }
     ],
     "wof:id":101919023,
-    "wof:lastmodified":1566600317,
+    "wof:lastmodified":1690855886,
     "wof:name":"Utuado",
     "wof:parent_id":102080433,
     "wof:placetype":"locality",

--- a/data/101/919/029/101919029.geojson
+++ b/data/101/919/029/101919029.geojson
@@ -29,10 +29,22 @@
     "name:ceb_x_preferred":[
         "A\u00f1asco"
     ],
+    "name:deu_x_preferred":[
+        "A\u00f1asco"
+    ],
     "name:eng_x_preferred":[
         "A\u00f1asco"
     ],
+    "name:epo_x_preferred":[
+        "A\u00f1asco"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0648\u0646\u0633\u06a9\u0648"
+    ],
     "name:fra_x_preferred":[
+        "A\u00f1asco"
+    ],
+    "name:gle_x_preferred":[
         "A\u00f1asco"
     ],
     "name:ita_x_preferred":[
@@ -44,8 +56,14 @@
     "name:nld_x_preferred":[
         "A\u00f1asco"
     ],
+    "name:pol_x_preferred":[
+        "A\u00f1asco"
+    ],
     "name:por_x_preferred":[
         "A\u00f1asco"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u043d\u044c\u044f\u0441\u043a\u043e"
     ],
     "name:spa_x_preferred":[
         "A\u00f1asco"
@@ -111,7 +129,7 @@
         }
     ],
     "wof:id":101919029,
-    "wof:lastmodified":1566600330,
+    "wof:lastmodified":1690855900,
     "wof:name":"A\u00f1asco",
     "wof:parent_id":102080323,
     "wof:placetype":"locality",

--- a/data/101/919/031/101919031.geojson
+++ b/data/101/919/031/101919031.geojson
@@ -29,10 +29,19 @@
     "name:ceb_x_preferred":[
         "Las Mar\u00edas"
     ],
+    "name:deu_x_preferred":[
+        "Las Mar\u00edas"
+    ],
     "name:eng_x_preferred":[
         "Las Mar\u00edas"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0627\u0633 \u0645\u0627\u0631\u06cc\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Las Mar\u00edas"
+    ],
+    "name:gle_x_preferred":[
         "Las Mar\u00edas"
     ],
     "name:ita_x_preferred":[
@@ -46,6 +55,9 @@
     ],
     "name:por_x_preferred":[
         "Las Mar\u00edas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u0430\u0441-\u041c\u0430\u0440\u0438\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Las Mar\u00edas"
@@ -111,7 +123,7 @@
         }
     ],
     "wof:id":101919031,
-    "wof:lastmodified":1566600321,
+    "wof:lastmodified":1690855890,
     "wof:name":"Las Mar\u00edas",
     "wof:parent_id":102080323,
     "wof:placetype":"locality",

--- a/data/101/919/035/101919035.geojson
+++ b/data/101/919/035/101919035.geojson
@@ -23,16 +23,31 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:azb_x_preferred":[
+        "\u0648\u06cc\u0644\u0627\u0644\u0628\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u09ad\u09bf\u09b2\u09cd\u09b2\u09be\u09b2\u09ac\u09be"
     ],
     "name:cat_x_preferred":[
         "Villalba"
     ],
+    "name:ceb_x_preferred":[
+        "Villalba Municipio"
+    ],
+    "name:deu_x_preferred":[
+        "Villalba"
+    ],
     "name:eng_x_preferred":[
         "Villalba"
     ],
+    "name:fas_x_preferred":[
+        "\u0648\u06cc\u0627\u0644\u0628\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Villalba"
+    ],
+    "name:gle_x_preferred":[
         "Villalba"
     ],
     "name:ita_x_preferred":[
@@ -41,8 +56,17 @@
     "name:jpn_x_preferred":[
         "\u30d3\u30b8\u30e3\u30eb\u30d0"
     ],
+    "name:lld_x_preferred":[
+        "Villalba"
+    ],
     "name:nld_x_preferred":[
         "Villalba"
+    ],
+    "name:por_x_preferred":[
+        "Villalba"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u0438\u043b\u044c\u044f\u043b\u044c\u0431\u0430"
     ],
     "name:scn_x_preferred":[
         "Villalba"
@@ -134,7 +158,7 @@
         }
     ],
     "wof:id":101919035,
-    "wof:lastmodified":1566600332,
+    "wof:lastmodified":1690855902,
     "wof:name":"Villalba",
     "wof:parent_id":102080377,
     "wof:placetype":"locality",

--- a/data/101/919/039/101919039.geojson
+++ b/data/101/919/039/101919039.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ara_x_preferred":[
+        "\u0643\u0627\u0628\u0648 \u0631\u0648\u062e\u0648"
+    ],
     "name:bpy_x_preferred":[
         "\u0995\u09be\u09ac\u09cb \u09b0\u09cb\u099c\u09cb"
     ],
@@ -44,7 +47,13 @@
     "name:epo_x_preferred":[
         "Cabo Rojo"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0628\u0648 \u0631\u0648\u062e\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Cabo Rojo"
+    ],
+    "name:gle_x_preferred":[
         "Cabo Rojo"
     ],
     "name:ita_x_preferred":[
@@ -52,6 +61,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ab\u30dc\u30fb\u30ed\u30c3\u30db"
+    ],
+    "name:lld_x_preferred":[
+        "Cabo Rojo"
     ],
     "name:nld_x_preferred":[
         "Cabo Rojo"
@@ -157,7 +169,7 @@
         }
     ],
     "wof:id":101919039,
-    "wof:lastmodified":1566600323,
+    "wof:lastmodified":1690855892,
     "wof:name":"Cabo Rojo",
     "wof:parent_id":102080409,
     "wof:placetype":"locality",

--- a/data/101/919/045/101919045.geojson
+++ b/data/101/919/045/101919045.geojson
@@ -26,6 +26,12 @@
     "name:eng_x_preferred":[
         "El combate"
     ],
+    "name:gle_x_preferred":[
+        "El combate"
+    ],
+    "name:hat_x_preferred":[
+        "El combate"
+    ],
     "name:por_x_preferred":[
         "El combate"
     ],
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":101919045,
-    "wof:lastmodified":1566600329,
+    "wof:lastmodified":1690855898,
     "wof:name":"El Combate",
     "wof:parent_id":102080409,
     "wof:placetype":"locality",

--- a/data/101/919/047/101919047.geojson
+++ b/data/101/919/047/101919047.geojson
@@ -23,16 +23,25 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Puerto Real Barrio"
+    ],
     "name:eng_x_preferred":[
         "Puerto Real"
     ],
     "name:fra_x_preferred":[
         "Puerto Real"
     ],
+    "name:ita_x_preferred":[
+        "Puerto Real"
+    ],
     "name:nld_x_preferred":[
         "Puerto Real"
     ],
     "name:por_x_preferred":[
+        "Puerto Real"
+    ],
+    "name:spa_x_preferred":[
         "Puerto Real"
     ],
     "name:srp_x_preferred":[
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":101919047,
-    "wof:lastmodified":1566600319,
+    "wof:lastmodified":1690855888,
     "wof:name":"Puerto Real",
     "wof:parent_id":102080409,
     "wof:placetype":"locality",

--- a/data/101/919/053/101919053.geojson
+++ b/data/101/919/053/101919053.geojson
@@ -32,10 +32,19 @@
     "name:ceb_x_preferred":[
         "Las Mar\u00edas"
     ],
+    "name:deu_x_preferred":[
+        "Las Mar\u00edas"
+    ],
     "name:eng_x_preferred":[
         "Las Mar\u00edas"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0627\u0633 \u0645\u0627\u0631\u06cc\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Las Mar\u00edas"
+    ],
+    "name:gle_x_preferred":[
         "Las Mar\u00edas"
     ],
     "name:ita_x_preferred":[
@@ -49,6 +58,9 @@
     ],
     "name:por_x_preferred":[
         "Las Mar\u00edas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u0430\u0441-\u041c\u0430\u0440\u0438\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Las Mar\u00edas"
@@ -131,7 +143,7 @@
         }
     ],
     "wof:id":101919053,
-    "wof:lastmodified":1566600320,
+    "wof:lastmodified":1690855889,
     "wof:name":"Las Mar\u00edas",
     "wof:parent_id":102080281,
     "wof:placetype":"locality",

--- a/data/101/919/055/101919055.geojson
+++ b/data/101/919/055/101919055.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Buena Vista Barrio"
+    ],
     "name:eng_x_preferred":[
         "Buena Vista"
     ],
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101919055,
-    "wof:lastmodified":1566600322,
+    "wof:lastmodified":1690855891,
     "wof:name":"Buena Vista",
     "wof:parent_id":102080285,
     "wof:placetype":"locality",

--- a/data/101/919/057/101919057.geojson
+++ b/data/101/919/057/101919057.geojson
@@ -41,10 +41,22 @@
     "name:eng_x_preferred":[
         "Arroyo"
     ],
+    "name:epo_x_preferred":[
+        "Arroyo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0631\u0648\u06cc\u0648"
+    ],
     "name:fra_x_preferred":[
         "Arroyo"
     ],
+    "name:gle_x_preferred":[
+        "Arroyo"
+    ],
     "name:hbs_x_preferred":[
+        "Arroyo"
+    ],
+    "name:ind_x_preferred":[
         "Arroyo"
     ],
     "name:ita_x_preferred":[
@@ -56,6 +68,9 @@
     "name:lit_x_preferred":[
         "Arojas"
     ],
+    "name:lld_x_preferred":[
+        "Arroyo"
+    ],
     "name:nld_x_preferred":[
         "Arroyo"
     ],
@@ -64,6 +79,9 @@
     ],
     "name:por_x_preferred":[
         "Arroyo"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0440\u0440\u043e\u0439\u043e"
     ],
     "name:spa_x_preferred":[
         "Arroyo"
@@ -152,7 +170,7 @@
         }
     ],
     "wof:id":101919057,
-    "wof:lastmodified":1566600333,
+    "wof:lastmodified":1690855904,
     "wof:name":"Arroyo",
     "wof:parent_id":102080285,
     "wof:placetype":"locality",

--- a/data/101/919/061/101919061.geojson
+++ b/data/101/919/061/101919061.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:cat_x_preferred":[
+        "Levittown"
+    ],
     "name:ceb_x_preferred":[
         "Levittown"
     ],
@@ -33,6 +36,9 @@
         "Levittown"
     ],
     "name:eng_x_preferred":[
+        "Levittown"
+    ],
+    "name:fra_x_preferred":[
         "Levittown"
     ],
     "name:nld_x_preferred":[
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":101919061,
-    "wof:lastmodified":1566600332,
+    "wof:lastmodified":1690855903,
     "wof:name":"Levittown",
     "wof:parent_id":102080329,
     "wof:placetype":"locality",

--- a/data/101/919/067/101919067.geojson
+++ b/data/101/919/067/101919067.geojson
@@ -23,6 +23,15 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062a\u0648\u0627\u0628\u0627\u062e\u0627"
+    ],
+    "name:azb_x_preferred":[
+        "\u062a\u0648\u0627 \u0628\u0627\u062c\u0627"
+    ],
+    "name:bpy_x_preferred":[
+        "\u099f\u09f1\u09be \u09ac\u09be\u099c\u09be"
+    ],
     "name:cat_x_preferred":[
         "Toa Baja"
     ],
@@ -38,7 +47,13 @@
     "name:eng_x_preferred":[
         "Toa Baja"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0648\u0622 \u0628\u0627\u062e\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Toa Baja"
+    ],
+    "name:gle_x_preferred":[
         "Toa Baja"
     ],
     "name:ita_x_preferred":[
@@ -47,11 +62,20 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30a2\u30fb\u30d0\u30cf"
     ],
+    "name:lld_x_preferred":[
+        "Toa Baja"
+    ],
     "name:nld_x_preferred":[
+        "Toa Baja"
+    ],
+    "name:pol_x_preferred":[
         "Toa Baja"
     ],
     "name:por_x_preferred":[
         "Toa Baixa"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u043e\u0430-\u0411\u0430\u0445\u0430"
     ],
     "name:scn_x_preferred":[
         "Toa Baja"
@@ -61,6 +85,9 @@
     ],
     "name:srp_x_preferred":[
         "\u0422\u043e\u0430 \u0411\u0430\u0445\u0430"
+    ],
+    "name:swe_x_preferred":[
+        "Toa Baja"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u043e\u0430-\u0411\u0430\u0445\u0430"
@@ -143,7 +170,7 @@
         }
     ],
     "wof:id":101919067,
-    "wof:lastmodified":1566600334,
+    "wof:lastmodified":1690855906,
     "wof:name":"Toa Baja",
     "wof:parent_id":102080329,
     "wof:placetype":"locality",

--- a/data/101/919/077/101919077.geojson
+++ b/data/101/919/077/101919077.geojson
@@ -20,11 +20,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:ceb_x_preferred":[
+        "Maguayo Barrio"
+    ],
     "name:eng_x_preferred":[
+        "Maguayo"
+    ],
+    "name:lld_x_preferred":[
         "Maguayo"
     ],
     "name:spa_x_preferred":[
         "Maguayo"
+    ],
+    "name:srp_x_preferred":[
+        "\u041c\u0430\u0433\u0432\u0430\u0458\u043e"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -71,7 +80,7 @@
         }
     ],
     "wof:id":101919077,
-    "wof:lastmodified":1566600318,
+    "wof:lastmodified":1690855887,
     "wof:name":"Maguayo",
     "wof:parent_id":102080327,
     "wof:placetype":"locality",

--- a/data/101/919/081/101919081.geojson
+++ b/data/101/919/081/101919081.geojson
@@ -44,7 +44,16 @@
     "name:eng_x_preferred":[
         "Lajas"
     ],
+    "name:epo_x_preferred":[
+        "Lajas"
+    ],
+    "name:fas_x_preferred":[
+        "\u0644\u0627\u062e\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Lajas"
+    ],
+    "name:gle_x_preferred":[
         "Lajas"
     ],
     "name:ita_x_preferred":[
@@ -53,6 +62,9 @@
     "name:jpn_x_preferred":[
         "\u30e9\u30cf\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Lajas"
+    ],
     "name:nld_x_preferred":[
         "Lajas"
     ],
@@ -60,6 +72,9 @@
         "Lajas"
     ],
     "name:nob_x_preferred":[
+        "Lajas"
+    ],
+    "name:pol_x_preferred":[
         "Lajas"
     ],
     "name:por_x_preferred":[
@@ -155,7 +170,7 @@
         }
     ],
     "wof:id":101919081,
-    "wof:lastmodified":1566600330,
+    "wof:lastmodified":1690855900,
     "wof:name":"Lajas",
     "wof:parent_id":102080327,
     "wof:placetype":"locality",

--- a/data/101/919/083/101919083.geojson
+++ b/data/101/919/083/101919083.geojson
@@ -29,6 +29,9 @@
     "name:eng_x_preferred":[
         "La Parguera"
     ],
+    "name:lld_x_preferred":[
+        "La Parguera"
+    ],
     "name:nld_x_preferred":[
         "La Parguera"
     ],
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101919083,
-    "wof:lastmodified":1566600318,
+    "wof:lastmodified":1690855887,
     "wof:name":"La Parguera",
     "wof:parent_id":102080327,
     "wof:placetype":"locality",

--- a/data/101/919/089/101919089.geojson
+++ b/data/101/919/089/101919089.geojson
@@ -47,7 +47,13 @@
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0631\u0648\u0632\u0627\u0644"
     ],
+    "name:fas_x_variant":[
+        "\u06a9\u0631\u0648\u0632\u0627\u0644"
+    ],
     "name:fra_x_preferred":[
+        "Corozal"
+    ],
+    "name:gle_x_preferred":[
         "Corozal"
     ],
     "name:hbs_x_preferred":[
@@ -74,6 +80,9 @@
     "name:kor_x_preferred":[
         "\ucf54\ub85c\uc798"
     ],
+    "name:lld_x_preferred":[
+        "Corozal"
+    ],
     "name:nld_x_preferred":[
         "Corozal"
     ],
@@ -82,6 +91,9 @@
     ],
     "name:por_x_preferred":[
         "Corozal"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u0440\u043e\u0441\u0430\u043b\u044c"
     ],
     "name:spa_x_preferred":[
         "Corozal"
@@ -178,7 +190,7 @@
         }
     ],
     "wof:id":101919089,
-    "wof:lastmodified":1636502703,
+    "wof:lastmodified":1690855898,
     "wof:name":"Corozal",
     "wof:parent_id":102080369,
     "wof:placetype":"locality",

--- a/data/101/919/091/101919091.geojson
+++ b/data/101/919/091/101919091.geojson
@@ -44,7 +44,13 @@
     "name:epo_x_preferred":[
         "Ceiba"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0627\u06cc\u0628\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Ceiba"
+    ],
+    "name:gle_x_preferred":[
         "Ceiba"
     ],
     "name:ita_x_preferred":[
@@ -55,6 +61,9 @@
     ],
     "name:kaz_x_preferred":[
         "\u0421\u0435\u0439\u0431\u0430"
+    ],
+    "name:lld_x_preferred":[
+        "Ceiba"
     ],
     "name:nld_x_preferred":[
         "Ceiba"
@@ -70,6 +79,9 @@
     ],
     "name:srp_x_preferred":[
         "\u0421\u0435\u0438\u0431\u0430"
+    ],
+    "name:swe_x_preferred":[
+        "Ceiba"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0435\u0439\u0431\u0430"
@@ -152,7 +164,7 @@
         }
     ],
     "wof:id":101919091,
-    "wof:lastmodified":1566600320,
+    "wof:lastmodified":1690855889,
     "wof:name":"Ceiba",
     "wof:parent_id":102080341,
     "wof:placetype":"locality",

--- a/data/101/919/095/101919095.geojson
+++ b/data/101/919/095/101919095.geojson
@@ -20,8 +20,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:ara_x_preferred":[
+        "\u0633\u0627\u0646 \u062e\u064a\u0631\u0645\u0627\u0646"
+    ],
+    "name:bpy_x_preferred":[
+        "\u09b8\u09be\u09a8 \u099c\u09be\u09b0\u09cd\u09ae\u09be\u09a8"
+    ],
     "name:cat_x_preferred":[
         "San Germ\u00e1n"
+    ],
+    "name:ceb_x_preferred":[
+        "San Germ\u00e1n Municipio"
     ],
     "name:cym_x_preferred":[
         "San Germ\u00e1n"
@@ -35,14 +44,26 @@
     "name:epo_x_preferred":[
         "San Germ\u00e1n"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0646 \u0698\u0631\u0645\u0646"
+    ],
     "name:fra_x_preferred":[
         "San Germ\u00e1n"
+    ],
+    "name:gle_x_preferred":[
+        "San Germ\u00e1n"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d0\u05df \u05d7\u05e8\u05de\u05d9\u05d0\u05df"
     ],
     "name:ita_x_preferred":[
         "San Germ\u00e1n"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30d8\u30eb\u30de\u30f3"
+    ],
+    "name:lld_x_preferred":[
+        "San Germ\u00e1n"
     ],
     "name:nld_x_preferred":[
         "San Germ\u00e1n"
@@ -126,7 +147,7 @@
         }
     ],
     "wof:id":101919095,
-    "wof:lastmodified":1566600332,
+    "wof:lastmodified":1690855903,
     "wof:name":"San Germ\u00e1n",
     "wof:parent_id":102080357,
     "wof:placetype":"locality",

--- a/data/101/919/099/101919099.geojson
+++ b/data/101/919/099/101919099.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u064a\u0627\u0645\u0648\u0646"
     ],
+    "name:azb_x_preferred":[
+        "\u0628\u0627\u06cc\u0627\u0645\u0648\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "Bayamon"
+    ],
     "name:bpy_x_preferred":[
         "\u09ac\u09be\u09af\u09bc\u09be\u09ae\u09a8"
     ],
@@ -62,6 +68,12 @@
     "name:fra_x_preferred":[
         "Bayam\u00f3n"
     ],
+    "name:gle_x_preferred":[
+        "Bayam\u00f3n"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d0\u05d9\u05d0\u05de\u05d5\u05df"
+    ],
     "name:hin_x_preferred":[
         "\u092c\u092f\u093e\u092e\u094b\u0902"
     ],
@@ -76,6 +88,9 @@
     ],
     "name:lit_x_preferred":[
         "Bajamonas"
+    ],
+    "name:lld_x_preferred":[
+        "Bayam\u00f3n"
     ],
     "name:mkd_x_preferred":[
         "\u0411\u0430\u0458\u0430\u043c\u043e\u043d"
@@ -101,6 +116,9 @@
     "name:srp_x_preferred":[
         "\u0411\u0430\u0458\u0430\u043c\u043e\u043d"
     ],
+    "name:swa_x_preferred":[
+        "Bayam\u00f3n"
+    ],
     "name:swe_x_preferred":[
         "Bayam\u00f3n"
     ],
@@ -124,6 +142,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u963f\u8499"
+    ],
+    "name:zho_x_variant":[
+        "\u5df4\u4e9a\u8499"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -168,7 +189,7 @@
         }
     ],
     "wof:id":101919099,
-    "wof:lastmodified":1566600321,
+    "wof:lastmodified":1690855891,
     "wof:name":"Bayam\u00f3n",
     "wof:parent_id":102080345,
     "wof:placetype":"locality",

--- a/data/101/919/103/101919103.geojson
+++ b/data/101/919/103/101919103.geojson
@@ -32,10 +32,19 @@
     "name:ceb_x_preferred":[
         "Cidra Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Cidra"
+    ],
     "name:eng_x_preferred":[
         "Cidra"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u06cc\u062f\u0631\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Cidra"
+    ],
+    "name:gle_x_preferred":[
         "Cidra"
     ],
     "name:ita_x_preferred":[
@@ -44,11 +53,20 @@
     "name:jpn_x_preferred":[
         "\u30b7\u30c9\u30e9"
     ],
+    "name:lld_x_preferred":[
+        "Cidra"
+    ],
     "name:nld_x_preferred":[
+        "Cidra"
+    ],
+    "name:pol_x_preferred":[
         "Cidra"
     ],
     "name:por_x_preferred":[
         "Cidra"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0438\u0434\u0440\u0430"
     ],
     "name:spa_x_preferred":[
         "Cidra"
@@ -137,7 +155,7 @@
         }
     ],
     "wof:id":101919103,
-    "wof:lastmodified":1566600315,
+    "wof:lastmodified":1690855883,
     "wof:name":"Cidra",
     "wof:parent_id":102080345,
     "wof:placetype":"locality",

--- a/data/101/919/111/101919111.geojson
+++ b/data/101/919/111/101919111.geojson
@@ -29,10 +29,22 @@
     "name:cat_x_preferred":[
         "Morovis"
     ],
+    "name:ceb_x_preferred":[
+        "Morovis Municipio"
+    ],
+    "name:deu_x_preferred":[
+        "Morovis"
+    ],
     "name:eng_x_preferred":[
         "Morovis"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0648\u0631\u0648\u06cc\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Morovis"
+    ],
+    "name:gle_x_preferred":[
         "Morovis"
     ],
     "name:ita_x_preferred":[
@@ -41,8 +53,17 @@
     "name:jpn_x_preferred":[
         "\u30e2\u30ed\u30d3\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Morovis"
+    ],
     "name:nld_x_preferred":[
         "Morovis"
+    ],
+    "name:por_x_preferred":[
+        "Morovis"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u043e\u0440\u043e\u0432\u0438\u0441"
     ],
     "name:spa_x_preferred":[
         "Morovis"
@@ -131,7 +152,7 @@
         }
     ],
     "wof:id":101919111,
-    "wof:lastmodified":1566600325,
+    "wof:lastmodified":1690855893,
     "wof:name":"Morovis",
     "wof:parent_id":102080401,
     "wof:placetype":"locality",

--- a/data/101/919/117/101919117.geojson
+++ b/data/101/919/117/101919117.geojson
@@ -26,16 +26,34 @@
     "name:bpy_x_preferred":[
         "\u09ae\u09be\u09b0\u09bf\u0995\u09be\u0993"
     ],
+    "name:bre_x_preferred":[
+        "Maricao"
+    ],
     "name:cat_x_preferred":[
         "Maricao"
     ],
     "name:ceb_x_preferred":[
         "Maricao"
     ],
+    "name:ceb_x_variant":[
+        "Maricao Municipio"
+    ],
+    "name:deu_x_preferred":[
+        "Maricao"
+    ],
     "name:eng_x_preferred":[
         "Maricao"
     ],
+    "name:eus_x_preferred":[
+        "Maricao"
+    ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0631\u06cc\u06a9\u0627\u0626\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Maricao"
+    ],
+    "name:gle_x_preferred":[
         "Maricao"
     ],
     "name:ita_x_preferred":[
@@ -44,8 +62,17 @@
     "name:jpn_x_preferred":[
         "\u30de\u30ea\u30ab\u30aa"
     ],
+    "name:lld_x_preferred":[
+        "Maricao"
+    ],
     "name:nld_x_preferred":[
         "Maricao"
+    ],
+    "name:por_x_preferred":[
+        "Maricao"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u0440\u0438\u043a\u0430\u043e"
     ],
     "name:spa_x_preferred":[
         "Maricao"
@@ -137,7 +164,7 @@
         }
     ],
     "wof:id":101919117,
-    "wof:lastmodified":1566600327,
+    "wof:lastmodified":1690855896,
     "wof:name":"Maricao",
     "wof:parent_id":102080437,
     "wof:placetype":"locality",

--- a/data/101/919/119/101919119.geojson
+++ b/data/101/919/119/101919119.geojson
@@ -26,6 +26,9 @@
     "name:ara_x_preferred":[
         "\u0641\u064a\u0643\u0648\u064a\u0633"
     ],
+    "name:azb_x_preferred":[
+        "\u0648\u06cc\u06a9\u0648\u0632"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0412'\u0435\u043a\u0435\u0441"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ceb_x_preferred":[
         "Vieques Island"
+    ],
+    "name:ceb_x_variant":[
+        "Vieques Municipality"
     ],
     "name:ces_x_preferred":[
         "Vieques"
@@ -59,10 +65,16 @@
     "name:est_x_preferred":[
         "Vieques"
     ],
+    "name:fas_x_preferred":[
+        "\u0648\u06cc\u06a9"
+    ],
     "name:fin_x_preferred":[
         "Vieques"
     ],
     "name:fra_x_preferred":[
+        "Vieques"
+    ],
+    "name:gle_x_preferred":[
         "Vieques"
     ],
     "name:heb_x_preferred":[
@@ -70,6 +82,9 @@
     ],
     "name:hye_x_preferred":[
         "\u053d\u0565\u0581\u0563\u0565\u057f\u0576\u056b \u056f\u0572\u0566\u056b"
+    ],
+    "name:ind_x_preferred":[
+        "Vieques"
     ],
     "name:ita_x_preferred":[
         "Vieques"
@@ -88,6 +103,9 @@
     ],
     "name:lit_x_preferred":[
         "Vjekesas"
+    ],
+    "name:lld_x_preferred":[
+        "Vieques"
     ],
     "name:nld_x_preferred":[
         "Vieques"
@@ -117,6 +135,12 @@
         "Vieques"
     ],
     "name:srp_x_preferred":[
+        "Vieques"
+    ],
+    "name:swe_x_preferred":[
+        "Vieques"
+    ],
+    "name:tur_x_preferred":[
         "Vieques"
     ],
     "name:ukr_x_preferred":[
@@ -203,7 +227,7 @@
         }
     ],
     "wof:id":101919119,
-    "wof:lastmodified":1566600326,
+    "wof:lastmodified":1690855895,
     "wof:name":"Vieques",
     "wof:parent_id":102080315,
     "wof:placetype":"locality",

--- a/data/101/919/125/101919125.geojson
+++ b/data/101/919/125/101919125.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u064a\u0627\u0645\u0648\u0646"
     ],
+    "name:azb_x_preferred":[
+        "\u0628\u0627\u06cc\u0627\u0645\u0648\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "Bayamon"
+    ],
     "name:bpy_x_preferred":[
         "\u09ac\u09be\u09af\u09bc\u09be\u09ae\u09a8"
     ],
@@ -62,6 +68,12 @@
     "name:fra_x_preferred":[
         "Bayam\u00f3n"
     ],
+    "name:gle_x_preferred":[
+        "Bayam\u00f3n"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d0\u05d9\u05d0\u05de\u05d5\u05df"
+    ],
     "name:hin_x_preferred":[
         "\u092c\u092f\u093e\u092e\u094b\u0902"
     ],
@@ -76,6 +88,9 @@
     ],
     "name:lit_x_preferred":[
         "Bajamonas"
+    ],
+    "name:lld_x_preferred":[
+        "Bayam\u00f3n"
     ],
     "name:mkd_x_preferred":[
         "\u0411\u0430\u0458\u0430\u043c\u043e\u043d"
@@ -101,6 +116,9 @@
     "name:srp_x_preferred":[
         "\u0411\u0430\u0458\u0430\u043c\u043e\u043d"
     ],
+    "name:swa_x_preferred":[
+        "Bayam\u00f3n"
+    ],
     "name:swe_x_preferred":[
         "Bayam\u00f3n"
     ],
@@ -124,6 +142,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u963f\u8499"
+    ],
+    "name:zho_x_variant":[
+        "\u5df4\u4e9a\u8499"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -168,7 +189,7 @@
         }
     ],
     "wof:id":101919125,
-    "wof:lastmodified":1566600336,
+    "wof:lastmodified":1690855907,
     "wof:name":"Bayam\u00f3n",
     "wof:parent_id":102080443,
     "wof:placetype":"locality",

--- a/data/101/919/127/101919127.geojson
+++ b/data/101/919/127/101919127.geojson
@@ -23,13 +23,22 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Bajadero"
+    ],
     "name:eng_x_preferred":[
         "Bajadero"
     ],
     "name:hbs_x_preferred":[
         "Bajadero"
     ],
+    "name:lld_x_preferred":[
+        "Bajadero"
+    ],
     "name:nld_x_preferred":[
+        "Bajadero"
+    ],
+    "name:spa_x_preferred":[
         "Bajadero"
     ],
     "name:srp_x_preferred":[
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":101919127,
-    "wof:lastmodified":1566600325,
+    "wof:lastmodified":1690855894,
     "wof:name":"Bajadero",
     "wof:parent_id":102080283,
     "wof:placetype":"locality",

--- a/data/101/919/135/101919135.geojson
+++ b/data/101/919/135/101919135.geojson
@@ -62,10 +62,19 @@
     "name:epo_x_preferred":[
         "Arecibo"
     ],
+    "name:eus_x_preferred":[
+        "Arecibo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0631\u0633\u06cc\u0628\u0648"
+    ],
     "name:fin_x_preferred":[
         "Arecibo"
     ],
     "name:fra_x_preferred":[
+        "Arecibo"
+    ],
+    "name:gle_x_preferred":[
         "Arecibo"
     ],
     "name:guj_x_preferred":[
@@ -101,6 +110,9 @@
     "name:lit_x_preferred":[
         "Aresibas"
     ],
+    "name:lld_x_preferred":[
+        "Arecibo"
+    ],
     "name:mar_x_preferred":[
         "\u0905\u0930\u093f\u0936\u093f\u0913"
     ],
@@ -122,6 +134,9 @@
     "name:por_x_preferred":[
         "Arecibo"
     ],
+    "name:ron_x_preferred":[
+        "Arecibo"
+    ],
     "name:rus_x_preferred":[
         "\u0410\u0440\u0435\u0441\u0438\u0431\u043e"
     ],
@@ -133,6 +148,9 @@
     ],
     "name:srp_x_preferred":[
         "\u0410\u0440\u0435\u0441\u0438\u0431\u043e"
+    ],
+    "name:swa_x_preferred":[
+        "Arecibo"
     ],
     "name:swe_x_preferred":[
         "Arecibo"
@@ -331,7 +349,7 @@
         }
     ],
     "wof:id":101919135,
-    "wof:lastmodified":1636502702,
+    "wof:lastmodified":1690855883,
     "wof:name":"Arecibo",
     "wof:parent_id":102080283,
     "wof:placetype":"locality",

--- a/data/101/919/137/101919137.geojson
+++ b/data/101/919/137/101919137.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:azb_x_preferred":[
+        "\u0622\u062f\u062c\u0648\u0646\u062a\u0627\u0633"
+    ],
     "name:bpy_x_preferred":[
         "\u0985\u09cd\u09af\u09be\u09a1\u099c\u09c1\u09a8\u099f\u09be\u09b8"
     ],
@@ -30,7 +33,13 @@
     "name:ceb_x_preferred":[
         "Adjuntas"
     ],
+    "name:deu_x_preferred":[
+        "Adjuntas"
+    ],
     "name:eng_x_preferred":[
+        "Adjuntas"
+    ],
+    "name:epo_x_preferred":[
         "Adjuntas"
     ],
     "name:fas_x_preferred":[
@@ -42,17 +51,29 @@
     "name:fra_x_preferred":[
         "Adjuntas"
     ],
+    "name:gle_x_preferred":[
+        "Adjuntas"
+    ],
     "name:ita_x_preferred":[
         "Adjuntas"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30c9\u30d5\u30f3\u30bf\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Adjuntas"
+    ],
     "name:nld_x_preferred":[
+        "Adjuntas"
+    ],
+    "name:pol_x_preferred":[
         "Adjuntas"
     ],
     "name:por_x_preferred":[
         "Adjuntas"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0434\u0445\u0443\u043d\u0442\u0430\u0441"
     ],
     "name:scn_x_preferred":[
         "Adjuntas"
@@ -130,7 +151,7 @@
         }
     ],
     "wof:id":101919137,
-    "wof:lastmodified":1566600329,
+    "wof:lastmodified":1690855897,
     "wof:name":"Adjuntas",
     "wof:parent_id":102080393,
     "wof:placetype":"locality",

--- a/data/101/919/143/101919143.geojson
+++ b/data/101/919/143/101919143.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:azb_x_preferred":[
+        "\u0622\u0642\u0648\u0627\u062f\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u0986\u0997\u09c1\u09f1\u09be\u09a1\u09be"
     ],
@@ -38,6 +41,9 @@
     "name:eng_x_preferred":[
         "Aguada"
     ],
+    "name:epo_x_preferred":[
+        "Aguada"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06af\u0648\u0627\u062f\u0627\u060c \u067e\u0648\u0626\u0631\u062a\u0648 \u0631\u06cc\u06a9\u0648"
     ],
@@ -47,11 +53,20 @@
     "name:fra_x_preferred":[
         "Aguada"
     ],
+    "name:gle_x_preferred":[
+        "Aguada"
+    ],
     "name:ita_x_preferred":[
         "Aguada"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30b0\u30a2\u30c0"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0410\u0433\u0443\u0430\u0434\u0430"
+    ],
+    "name:lld_x_preferred":[
+        "Aguada"
     ],
     "name:nld_x_preferred":[
         "Aguada"
@@ -152,7 +167,7 @@
         }
     ],
     "wof:id":101919143,
-    "wof:lastmodified":1566600325,
+    "wof:lastmodified":1690855894,
     "wof:name":"Aguada",
     "wof:parent_id":102080353,
     "wof:placetype":"locality",

--- a/data/101/919/147/101919147.geojson
+++ b/data/101/919/147/101919147.geojson
@@ -23,13 +23,25 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:azb_x_preferred":[
+        "\u0622\u06cc\u0628\u0648\u0646\u06cc\u062a\u0648"
+    ],
+    "name:bpy_x_preferred":[
+        "\u0986\u0987\u09ac\u09cb\u09a8\u09bf\u09a4\u09cb"
+    ],
     "name:cat_x_preferred":[
         "Aibonito"
     ],
     "name:ceb_x_preferred":[
         "Aibonito"
     ],
+    "name:deu_x_preferred":[
+        "Aibonito"
+    ],
     "name:eng_x_preferred":[
+        "Aibonito"
+    ],
+    "name:epo_x_preferred":[
         "Aibonito"
     ],
     "name:fas_x_preferred":[
@@ -41,11 +53,17 @@
     "name:fra_x_preferred":[
         "Aibonito"
     ],
+    "name:gle_x_preferred":[
+        "Aibonito"
+    ],
     "name:ita_x_preferred":[
         "Aibonito"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30a4\u30dc\u30cb\u30c8"
+    ],
+    "name:lld_x_preferred":[
+        "Aibonito"
     ],
     "name:nld_x_preferred":[
         "Aibonito"
@@ -55,6 +73,9 @@
     ],
     "name:por_x_preferred":[
         "Aibonito"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0439\u0431\u043e\u043d\u0438\u0442\u043e"
     ],
     "name:scn_x_preferred":[
         "Aibonito"
@@ -149,7 +170,7 @@
         }
     ],
     "wof:id":101919147,
-    "wof:lastmodified":1566600336,
+    "wof:lastmodified":1690855907,
     "wof:name":"Aibonito",
     "wof:parent_id":102080431,
     "wof:placetype":"locality",

--- a/data/101/919/157/101919157.geojson
+++ b/data/101/919/157/101919157.geojson
@@ -32,13 +32,22 @@
     "name:ceb_x_preferred":[
         "Barceloneta"
     ],
+    "name:deu_x_preferred":[
+        "Barceloneta"
+    ],
     "name:eng_x_preferred":[
         "Barceloneta"
     ],
     "name:epo_x_preferred":[
         "Barceloneto"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u0631\u0633\u0644\u0648\u0646\u062a\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Barceloneta"
+    ],
+    "name:gle_x_preferred":[
         "Barceloneta"
     ],
     "name:hbs_x_preferred":[
@@ -50,17 +59,26 @@
     "name:jpn_x_preferred":[
         "\u30d0\u30eb\u30bb\u30ed\u30cd\u30bf"
     ],
+    "name:lld_x_preferred":[
+        "Barceloneta"
+    ],
     "name:nld_x_preferred":[
         "Barceloneta"
     ],
     "name:por_x_preferred":[
         "Barceloneta"
     ],
+    "name:rus_x_preferred":[
+        "\u0411\u0430\u0440\u0441\u0435\u043b\u043e\u043d\u0435\u0442\u0430"
+    ],
     "name:spa_x_preferred":[
         "Barceloneta"
     ],
     "name:srp_x_preferred":[
         "\u0411\u0430\u0440\u0441\u0435\u043b\u043e\u043d\u0435\u0442\u0430"
+    ],
+    "name:swe_x_preferred":[
+        "Barceloneta"
     ],
     "name:ukr_x_preferred":[
         "\u0411\u0430\u0440\u0441\u0435\u043b\u043e\u043d\u0435\u0442\u0430"
@@ -148,7 +166,7 @@
         }
     ],
     "wof:id":101919157,
-    "wof:lastmodified":1566600316,
+    "wof:lastmodified":1690855884,
     "wof:name":"Barceloneta",
     "wof:parent_id":102080375,
     "wof:placetype":"locality",

--- a/data/101/919/171/101919171.geojson
+++ b/data/101/919/171/101919171.geojson
@@ -29,6 +29,9 @@
     "name:arg_x_preferred":[
         "Primera divisi\u00f3n espanyola de f\u00fatbol"
     ],
+    "name:ary_x_preferred":[
+        "\u0627\u0644\u0644\u064a\u06ad\u0627 \u0627\u0644\u0635\u0628\u0644\u064a\u0648\u0646\u064a\u0629"
+    ],
     "name:arz_x_preferred":[
         "\u0644\u0627 \u0644\u064a\u062c\u0627"
     ],
@@ -44,6 +47,12 @@
     "name:aze_x_preferred":[
         "La Liqa"
     ],
+    "name:aze_x_variant":[
+        "LaLiqa"
+    ],
+    "name:ban_x_preferred":[
+        "La Liga"
+    ],
     "name:bel_x_preferred":[
         "\u041b\u0430 \u041b\u0456\u0433\u0430"
     ],
@@ -55,6 +64,9 @@
     ],
     "name:bos_x_preferred":[
         "La Liga"
+    ],
+    "name:bos_x_variant":[
+        "LaLiga"
     ],
     "name:bul_x_preferred":[
         "\u041f\u0440\u0438\u043c\u0435\u0440\u0430 \u0434\u0438\u0432\u0438\u0441\u0438\u043e\u043d"
@@ -77,8 +89,14 @@
     "name:cym_x_preferred":[
         "La Liga"
     ],
+    "name:cym_x_variant":[
+        "LaLiga"
+    ],
     "name:dan_x_preferred":[
         "La Liga"
+    ],
+    "name:dan_x_variant":[
+        "LaLiga"
     ],
     "name:deu_x_preferred":[
         "Primera Divisi\u00f3n"
@@ -107,6 +125,9 @@
     "name:fao_x_preferred":[
         "La Liga"
     ],
+    "name:fao_x_variant":[
+        "LaLiga"
+    ],
     "name:fas_x_preferred":[
         "\u0644\u0627 \u0644\u06cc\u06af\u0627"
     ],
@@ -125,6 +146,9 @@
     "name:glg_x_variant":[
         "Primeira Divisi\u00f3n Espa\u00f1ola"
     ],
+    "name:glk_x_preferred":[
+        "\u0644\u0627\u0644\u064a\u06af\u0627"
+    ],
     "name:heb_x_preferred":[
         "\u05dc\u05d9\u05d2\u05ea \u05d4\u05e2\u05dc \u05d4\u05e1\u05e4\u05e8\u05d3\u05d9\u05ea \u05d1\u05db\u05d3\u05d5\u05e8\u05d2\u05dc"
     ],
@@ -137,6 +161,9 @@
     "name:hrv_x_preferred":[
         "La Liga"
     ],
+    "name:hrv_x_variant":[
+        "LaLiga"
+    ],
     "name:hun_x_preferred":[
         "Spanyol labdar\u00fag\u00f3-bajnoks\u00e1g"
     ],
@@ -146,20 +173,33 @@
     "name:hye_x_preferred":[
         "\u053c\u0561 \u053c\u056b\u0563\u0561"
     ],
+    "name:ibo_x_preferred":[
+        "La Liga"
+    ],
     "name:ind_x_preferred":[
         "La Liga"
     ],
+    "name:ind_x_variant":[
+        "LaLiga"
+    ],
     "name:isl_x_preferred":[
         "La Liga"
+    ],
+    "name:isl_x_variant":[
+        "LaLiga"
     ],
     "name:ita_x_preferred":[
         "Primera Divisi\u00f3n"
     ],
     "name:ita_x_variant":[
-        "Liga Spagnola"
+        "Liga Spagnola",
+        "LaLiga Spagnola"
     ],
     "name:jav_x_preferred":[
         "La Liga"
+    ],
+    "name:jav_x_variant":[
+        "LaLiga"
     ],
     "name:jpn_x_preferred":[
         "\u30d7\u30ea\u30e1\u30fc\u30e9\u30fb\u30c7\u30a3\u30d3\u30b7\u30aa\u30f3"
@@ -169,6 +209,9 @@
     ],
     "name:kaa_x_preferred":[
         "La Liga"
+    ],
+    "name:kaa_x_variant":[
+        "LaLiga"
     ],
     "name:kat_x_preferred":[
         "\u10d4\u10e1\u10de\u10d0\u10dc\u10d4\u10d7\u10d8\u10e1 \u10de\u10e0\u10d8\u10db\u10d4\u10e0\u10d0 \u10d3\u10d8\u10d5\u10d8\u10d6\u10d8\u10dd\u10dc\u10d8"
@@ -188,6 +231,9 @@
     "name:kur_x_preferred":[
         "La liga"
     ],
+    "name:kur_x_variant":[
+        "LaLiga"
+    ],
     "name:lav_x_preferred":[
         "Sp\u0101nijas futbola \u010dempion\u0101ta Pirm\u0101 div\u012bzija"
     ],
@@ -196,6 +242,9 @@
     ],
     "name:lit_x_preferred":[
         "La Liga"
+    ],
+    "name:lit_x_variant":[
+        "LaLiga"
     ],
     "name:mai_x_preferred":[
         "\u0932\u093e \u0932\u093f\u0917\u093e"
@@ -209,14 +258,26 @@
     "name:min_x_preferred":[
         "La Liga"
     ],
+    "name:min_x_variant":[
+        "LaLiga"
+    ],
     "name:mkd_x_preferred":[
         "\u041f\u0440\u0438\u043c\u0435\u0440\u0430 \u0414\u0438\u0432\u0438\u0441\u0438\u043e\u043d"
+    ],
+    "name:mkd_x_variant":[
+        "\u041b\u0430 \u041b\u0438\u0433\u0430"
     ],
     "name:mlt_x_preferred":[
         "La Liga"
     ],
+    "name:mlt_x_variant":[
+        "LaLiga"
+    ],
     "name:msa_x_preferred":[
         "La Liga"
+    ],
+    "name:msa_x_variant":[
+        "LaLiga"
     ],
     "name:mya_x_preferred":[
         "\u101c\u102c \u101c\u102e\u1002\u102b"
@@ -235,6 +296,9 @@
     ],
     "name:nor_x_preferred":[
         "Primera Divisi\u00f3n"
+    ],
+    "name:pap_x_preferred":[
+        "Prom\u00e9 Divishon"
     ],
     "name:pol_x_preferred":[
         "Primera Divisi\u00f3n"
@@ -257,17 +321,32 @@
     "name:sco_x_preferred":[
         "La Liga"
     ],
+    "name:sco_x_variant":[
+        "LaLiga"
+    ],
+    "name:shn_x_preferred":[
+        "\u101c\u1083\u1087 \u101c\u102e\u1075\u1083\u1087"
+    ],
     "name:slk_x_preferred":[
         "La Liga"
     ],
+    "name:slk_x_variant":[
+        "LaLiga"
+    ],
     "name:slv_x_preferred":[
         "La Liga"
+    ],
+    "name:slv_x_variant":[
+        "LaLiga"
     ],
     "name:spa_x_preferred":[
         "Primera Divisi\u00f3n de Espa\u00f1a"
     ],
     "name:sqi_x_preferred":[
         "La Liga"
+    ],
+    "name:sqi_x_variant":[
+        "LaLiga"
     ],
     "name:srd_x_preferred":[
         "Primera Divisi\u00f3n"
@@ -278,14 +357,23 @@
     "name:swa_x_preferred":[
         "La Liga"
     ],
+    "name:swa_x_variant":[
+        "LaLiga"
+    ],
     "name:swe_x_preferred":[
         "La Liga"
+    ],
+    "name:swe_x_variant":[
+        "LaLiga"
     ],
     "name:tam_x_preferred":[
         "\u0bb2\u0bbe \u0bb2\u0bc0\u0b95\u0bbe"
     ],
     "name:tat_x_preferred":[
         "La Liga"
+    ],
+    "name:tat_x_variant":[
+        "LaLiga"
     ],
     "name:tha_x_preferred":[
         "\u0e25\u0e32\u0e25\u0e35\u0e01\u0e32"
@@ -296,6 +384,9 @@
     "name:tur_x_preferred":[
         "La Liga"
     ],
+    "name:tur_x_variant":[
+        "LaLiga"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u0430-\u041b\u0456\u0433\u0430"
     ],
@@ -304,6 +395,9 @@
     ],
     "name:uzb_x_preferred":[
         "La Liga"
+    ],
+    "name:uzb_x_variant":[
+        "LaLiga"
     ],
     "name:vie_x_preferred":[
         "Gi\u1ea3i b\u00f3ng \u0111\u00e1 v\u00f4 \u0111\u1ecbch qu\u1ed1c gia T\u00e2y Ban Nha"
@@ -316,6 +410,9 @@
     ],
     "name:zho_x_preferred":[
         "\u897f\u73ed\u7259\u8db3\u7403\u7532\u7ea7\u8054\u8d5b"
+    ],
+    "name:zho_x_variant":[
+        "\u897f\u73ed\u7259\u8db3\u7403\u7532\u7d1a\u806f\u8cfd"
     ],
     "name:zho_yue_x_preferred":[
         "\u897f\u73ed\u7259\u7532\u7d44\u8db3\u7403\u806f\u8cfd"
@@ -365,7 +462,7 @@
         }
     ],
     "wof:id":101919171,
-    "wof:lastmodified":1566600337,
+    "wof:lastmodified":1690855908,
     "wof:name":"La Liga",
     "wof:parent_id":102080425,
     "wof:placetype":"locality",

--- a/data/101/919/173/101919173.geojson
+++ b/data/101/919/173/101919173.geojson
@@ -26,6 +26,15 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u063a\u0648\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u062c\u0648\u0627\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Caguas"
+    ],
+    "name:bel_x_preferred":[
+        "\u041a\u0430\u0433\u0443\u0430\u0441"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u0997\u09cb\u09af\u09bc\u09be\u09b8"
     ],
@@ -56,10 +65,16 @@
     "name:epo_x_preferred":[
         "Caguas"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u06af\u0648\u0627\u0633"
+    ],
     "name:fin_x_preferred":[
         "Caguas"
     ],
     "name:fra_x_preferred":[
+        "Caguas"
+    ],
+    "name:gle_x_preferred":[
         "Caguas"
     ],
     "name:guj_x_preferred":[
@@ -89,6 +104,9 @@
     "name:kan_x_preferred":[
         "\u0c95\u0cc1\u0c97\u0cbe\u0cb8\u0ccd"
     ],
+    "name:kat_x_preferred":[
+        "\u10d9\u10d0\u10d2\u10e3\u10d0\u10e1\u10d8"
+    ],
     "name:kaz_x_preferred":[
         "\u041a\u0430\u0433\u0443\u0430\u0441"
     ],
@@ -100,6 +118,9 @@
     ],
     "name:lit_x_preferred":[
         "Kaguasas"
+    ],
+    "name:lld_x_preferred":[
+        "Caguas"
     ],
     "name:mar_x_preferred":[
         "\u0915\u0945\u0917\u0941\u0938"
@@ -122,6 +143,9 @@
     "name:por_x_preferred":[
         "Caguas"
     ],
+    "name:ron_x_preferred":[
+        "Caguas"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u0430\u0433\u0443\u0430\u0441"
     ],
@@ -136,6 +160,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0433\u0432\u0430\u0441"
+    ],
+    "name:swa_x_preferred":[
+        "Caguas"
     ],
     "name:swe_x_preferred":[
         "Caguas"
@@ -237,7 +264,7 @@
         }
     ],
     "wof:id":101919173,
-    "wof:lastmodified":1566600323,
+    "wof:lastmodified":1690855893,
     "wof:name":"Caguas",
     "wof:parent_id":102080425,
     "wof:placetype":"locality",

--- a/data/101/919/179/101919179.geojson
+++ b/data/101/919/179/101919179.geojson
@@ -32,10 +32,19 @@
     "name:ceb_x_preferred":[
         "Ciales"
     ],
+    "name:deu_x_preferred":[
+        "Ciales"
+    ],
     "name:eng_x_preferred":[
         "Ciales"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u06cc\u0627\u0644\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Ciales"
+    ],
+    "name:gle_x_preferred":[
         "Ciales"
     ],
     "name:hbs_x_preferred":[
@@ -46,6 +55,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b7\u30a2\u30ec\u30b9"
+    ],
+    "name:lld_x_preferred":[
+        "Ciales"
     ],
     "name:nld_x_preferred":[
         "Ciales"
@@ -147,7 +159,7 @@
         }
     ],
     "wof:id":101919179,
-    "wof:lastmodified":1566600336,
+    "wof:lastmodified":1690855907,
     "wof:name":"Ciales",
     "wof:parent_id":102080317,
     "wof:placetype":"locality",

--- a/data/101/919/181/101919181.geojson
+++ b/data/101/919/181/101919181.geojson
@@ -26,6 +26,9 @@
     "name:ceb_x_preferred":[
         "Lomas"
     ],
+    "name:ceb_x_variant":[
+        "Lomas Barrio"
+    ],
     "name:deu_x_preferred":[
         "Lomas"
     ],
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101919181,
-    "wof:lastmodified":1566600326,
+    "wof:lastmodified":1690855895,
     "wof:name":"Lomas",
     "wof:parent_id":102080387,
     "wof:placetype":"locality",

--- a/data/101/919/183/101919183.geojson
+++ b/data/101/919/183/101919183.geojson
@@ -32,10 +32,22 @@
     "name:ceb_x_preferred":[
         "Canovanas"
     ],
+    "name:deu_x_preferred":[
+        "Can\u00f3vanas"
+    ],
     "name:eng_x_preferred":[
         "Can\u00f3vanas"
     ],
+    "name:epo_x_preferred":[
+        "Can\u00f3vanas"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0646\u0648\u0648\u0627\u0646\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Can\u00f3vanas"
+    ],
+    "name:gle_x_preferred":[
         "Can\u00f3vanas"
     ],
     "name:ita_x_preferred":[
@@ -61,6 +73,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u043d\u043e\u0432\u0430\u043d\u0430\u0441"
+    ],
+    "name:swe_x_preferred":[
+        "Can\u00f3vanas"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u043d\u043e\u0432\u0430\u043d\u0430\u0441"
@@ -145,7 +160,7 @@
         }
     ],
     "wof:id":101919183,
-    "wof:lastmodified":1566600335,
+    "wof:lastmodified":1690855906,
     "wof:name":"Can\u00f3vanas",
     "wof:parent_id":102080387,
     "wof:placetype":"locality",

--- a/data/101/919/193/101919193.geojson
+++ b/data/101/919/193/101919193.geojson
@@ -32,10 +32,22 @@
     "name:ceb_x_preferred":[
         "Barranquitas"
     ],
+    "name:deu_x_preferred":[
+        "Barranquitas"
+    ],
     "name:eng_x_preferred":[
         "Barranquitas"
     ],
+    "name:epo_x_preferred":[
+        "Barranquitas"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u0631\u0631\u0627\u0646\u06a9\u06cc\u062a\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Barranquitas"
+    ],
+    "name:gle_x_preferred":[
         "Barranquitas"
     ],
     "name:ita_x_preferred":[
@@ -44,11 +56,17 @@
     "name:jpn_x_preferred":[
         "\u30d0\u30e9\u30f3\u30ad\u30bf\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Barranquitas"
+    ],
     "name:nld_x_preferred":[
         "Barranquitas"
     ],
     "name:por_x_preferred":[
         "Barranquitas"
+    ],
+    "name:rus_x_preferred":[
+        "\u0411\u0430\u0440\u0440\u0430\u043d\u043a\u0438\u0442\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Barranquitas"
@@ -138,7 +156,7 @@
         }
     ],
     "wof:id":101919193,
-    "wof:lastmodified":1566600317,
+    "wof:lastmodified":1690855885,
     "wof:name":"Barranquitas",
     "wof:parent_id":102080333,
     "wof:placetype":"locality",

--- a/data/101/919/197/101919197.geojson
+++ b/data/101/919/197/101919197.geojson
@@ -83,6 +83,9 @@
     "name:fra_x_preferred":[
         "Carolina"
     ],
+    "name:gle_x_preferred":[
+        "Carolina"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0ac7\u0ab0\u0acb\u0ab2\u0abf\u0aa8\u0abe"
     ],
@@ -115,6 +118,9 @@
     ],
     "name:lit_x_preferred":[
         "Karolina"
+    ],
+    "name:lld_x_preferred":[
+        "Carolina"
     ],
     "name:mar_x_preferred":[
         "\u0915\u0945\u0930\u094b\u0932\u093f\u0928\u093e"
@@ -149,7 +155,13 @@
     "name:srp_x_preferred":[
         "\u041a\u0430\u0440\u043e\u043b\u0438\u043d\u0430"
     ],
+    "name:swa_x_preferred":[
+        "Carolina"
+    ],
     "name:swe_x_preferred":[
+        "Carolina"
+    ],
+    "name:szl_x_preferred":[
         "Carolina"
     ],
     "name:tam_x_preferred":[
@@ -251,7 +263,7 @@
         }
     ],
     "wof:id":101919197,
-    "wof:lastmodified":1566600328,
+    "wof:lastmodified":1690855897,
     "wof:name":"Carolina",
     "wof:parent_id":102080347,
     "wof:placetype":"locality",

--- a/data/101/919/201/101919201.geojson
+++ b/data/101/919/201/101919201.geojson
@@ -35,10 +35,22 @@
     "name:dan_x_preferred":[
         "Cayey"
     ],
+    "name:deu_x_preferred":[
+        "Cayey"
+    ],
     "name:eng_x_preferred":[
         "Cayey"
     ],
+    "name:epo_x_preferred":[
+        "Cayey"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u06cc\u0626\u06cc"
+    ],
     "name:fra_x_preferred":[
+        "Cayey"
+    ],
+    "name:gle_x_preferred":[
         "Cayey"
     ],
     "name:heb_x_preferred":[
@@ -49,6 +61,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ab\u30b8\u30a7\u30a4"
+    ],
+    "name:lld_x_preferred":[
+        "Cayey"
     ],
     "name:nld_x_preferred":[
         "Cayey"
@@ -156,7 +171,7 @@
         }
     ],
     "wof:id":101919201,
-    "wof:lastmodified":1566600333,
+    "wof:lastmodified":1690855905,
     "wof:name":"Cayey",
     "wof:parent_id":102080419,
     "wof:placetype":"locality",

--- a/data/101/919/203/101919203.geojson
+++ b/data/101/919/203/101919203.geojson
@@ -23,11 +23,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:azb_x_preferred":[
+        "\u062a\u0627\u0644\u0627\u0628\u0648\u0627 \u0622\u0644\u062a\u0627"
+    ],
+    "name:ceb_x_preferred":[
+        "Tallaboa Alta Barrio"
+    ],
     "name:eng_x_preferred":[
+        "Tallaboa Alta"
+    ],
+    "name:nld_x_preferred":[
         "Tallaboa Alta"
     ],
     "name:spa_x_preferred":[
         "Tallaboa Alta"
+    ],
+    "name:srp_x_preferred":[
+        "\u0422\u0430\u0459\u0430\u0431\u043e\u0430 \u0410\u043b\u0442\u0430"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -92,7 +104,7 @@
         }
     ],
     "wof:id":101919203,
-    "wof:lastmodified":1566600321,
+    "wof:lastmodified":1690855890,
     "wof:name":"Tallaboa Alta",
     "wof:parent_id":102080319,
     "wof:placetype":"locality",

--- a/data/101/919/205/101919205.geojson
+++ b/data/101/919/205/101919205.geojson
@@ -23,14 +23,29 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Tallaboa"
+    ],
     "name:eng_x_preferred":[
+        "Tallaboa"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30bf\u30ea\u30e3\u30dc\u30a2"
+    ],
+    "name:lld_x_preferred":[
         "Tallaboa"
     ],
     "name:nld_x_preferred":[
         "Tallaboa"
     ],
+    "name:spa_x_preferred":[
+        "Tallaboa"
+    ],
     "name:srp_x_preferred":[
         "\u0422\u0430\u0459\u0430\u0431\u043e\u0430"
+    ],
+    "name:zho_x_preferred":[
+        "\u5854\u62c9\u535a\u963f"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -102,7 +117,7 @@
         }
     ],
     "wof:id":101919205,
-    "wof:lastmodified":1566600323,
+    "wof:lastmodified":1690855892,
     "wof:name":"Tallaboa",
     "wof:parent_id":102080319,
     "wof:placetype":"locality",

--- a/data/101/919/207/101919207.geojson
+++ b/data/101/919/207/101919207.geojson
@@ -20,6 +20,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:ceb_x_preferred":[
+        "Santo Domingo"
+    ],
     "name:eng_x_preferred":[
         "Santo Domingo"
     ],
@@ -30,6 +33,9 @@
         "Santo Domingo"
     ],
     "name:nld_x_preferred":[
+        "Santo Domingo"
+    ],
+    "name:spa_x_preferred":[
         "Santo Domingo"
     ],
     "name:srp_x_preferred":[
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":101919207,
-    "wof:lastmodified":1636502704,
+    "wof:lastmodified":1690855902,
     "wof:name":"Santo Domingo",
     "wof:parent_id":102080319,
     "wof:placetype":"locality",

--- a/data/101/919/209/101919209.geojson
+++ b/data/101/919/209/101919209.geojson
@@ -29,10 +29,19 @@
     "name:ceb_x_preferred":[
         "Pe\u00f1uelas Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
     "name:eng_x_preferred":[
         "Pe\u00f1uelas"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0648\u0646\u0648\u0626\u0644\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
+    "name:gle_x_preferred":[
         "Pe\u00f1uelas"
     ],
     "name:glg_x_preferred":[
@@ -47,8 +56,14 @@
     "name:nld_x_preferred":[
         "Pe\u00f1uelas"
     ],
+    "name:pol_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
     "name:por_x_preferred":[
         "Pe\u00f1uelas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0435\u043d\u044c\u044e\u044d\u043b\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Pe\u00f1uelas"
@@ -114,7 +129,7 @@
         }
     ],
     "wof:id":101919209,
-    "wof:lastmodified":1566600332,
+    "wof:lastmodified":1690855902,
     "wof:name":"Pe\u00f1uelas",
     "wof:parent_id":102080319,
     "wof:placetype":"locality",

--- a/data/101/919/215/101919215.geojson
+++ b/data/101/919/215/101919215.geojson
@@ -32,10 +32,19 @@
     "name:ceb_x_preferred":[
         "Maunabo"
     ],
+    "name:deu_x_preferred":[
+        "Maunabo"
+    ],
     "name:eng_x_preferred":[
         "Maunabo"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0648\u0646\u0627\u0628\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Maunabo"
+    ],
+    "name:gle_x_preferred":[
         "Maunabo"
     ],
     "name:hbs_x_preferred":[
@@ -47,8 +56,17 @@
     "name:jpn_x_preferred":[
         "\u30de\u30a6\u30ca\u30dc"
     ],
+    "name:lld_x_preferred":[
+        "Maunabo"
+    ],
     "name:nld_x_preferred":[
         "Maunabo"
+    ],
+    "name:por_x_preferred":[
+        "Maunabo"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u0443\u043d\u0430\u0431\u043e"
     ],
     "name:spa_x_preferred":[
         "Maunabo"
@@ -141,7 +159,7 @@
         }
     ],
     "wof:id":101919215,
-    "wof:lastmodified":1566600330,
+    "wof:lastmodified":1690855899,
     "wof:name":"Maunabo",
     "wof:parent_id":102080389,
     "wof:placetype":"locality",

--- a/data/101/919/219/101919219.geojson
+++ b/data/101/919/219/101919219.geojson
@@ -32,13 +32,22 @@
     "name:ceb_x_preferred":[
         "Florida Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Florida"
+    ],
     "name:eng_x_preferred":[
         "Florida"
     ],
     "name:epo_x_preferred":[
         "Florido"
     ],
+    "name:fas_x_preferred":[
+        "\u0641\u0644\u0648\u0631\u06cc\u062f\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Florida"
+    ],
+    "name:gle_x_preferred":[
         "Florida"
     ],
     "name:heb_x_preferred":[
@@ -53,11 +62,20 @@
     "name:jpn_x_preferred":[
         "\u30d5\u30ed\u30ea\u30c0"
     ],
+    "name:lld_x_preferred":[
+        "Florida"
+    ],
     "name:nld_x_preferred":[
+        "Florida"
+    ],
+    "name:pol_x_preferred":[
         "Florida"
     ],
     "name:por_x_preferred":[
         "Florida"
+    ],
+    "name:rus_x_preferred":[
+        "\u0424\u043b\u043e\u0440\u0438\u0434\u0430"
     ],
     "name:spa_x_preferred":[
         "Florida"
@@ -140,7 +158,7 @@
         }
     ],
     "wof:id":101919219,
-    "wof:lastmodified":1636502702,
+    "wof:lastmodified":1690855888,
     "wof:name":"Florida",
     "wof:parent_id":102080343,
     "wof:placetype":"locality",

--- a/data/101/919/227/101919227.geojson
+++ b/data/101/919/227/101919227.geojson
@@ -38,7 +38,13 @@
     "name:epo_x_preferred":[
         "Gu\u00e1nica"
     ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0627\u0646\u06cc\u06a9\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Gu\u00e1nica"
+    ],
+    "name:gle_x_preferred":[
         "Gu\u00e1nica"
     ],
     "name:ita_x_preferred":[
@@ -55,6 +61,9 @@
     ],
     "name:por_x_preferred":[
         "Gu\u00e1nica"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0443\u0430\u043d\u0438\u043a\u0430"
     ],
     "name:spa_x_preferred":[
         "Gu\u00e1nica"
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":101919227,
-    "wof:lastmodified":1566600318,
+    "wof:lastmodified":1690855886,
     "wof:name":"Gu\u00e1nica",
     "wof:parent_id":102080429,
     "wof:placetype":"locality",

--- a/data/101/919/237/101919237.geojson
+++ b/data/101/919/237/101919237.geojson
@@ -23,8 +23,14 @@
     "name:eng_x_preferred":[
         "Palmas Del Mar Beach Resort"
     ],
+    "name:lld_x_preferred":[
+        "Palmas del Mar"
+    ],
     "name:spa_x_preferred":[
         "Palmas del Mar Beach Resort"
+    ],
+    "name:srp_x_preferred":[
+        "\u041f\u0430\u043b\u043c\u0430\u0441 \u0434\u0435\u043b \u041c\u0430\u0440"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -71,7 +77,7 @@
         }
     ],
     "wof:id":101919237,
-    "wof:lastmodified":1566600333,
+    "wof:lastmodified":1690855905,
     "wof:name":"Palmas del Mar",
     "wof:parent_id":102080351,
     "wof:placetype":"locality",

--- a/data/101/919/245/101919245.geojson
+++ b/data/101/919/245/101919245.geojson
@@ -33,10 +33,19 @@
     "name:dan_x_preferred":[
         "Humacao"
     ],
+    "name:deu_x_preferred":[
+        "Humacao"
+    ],
     "name:eng_x_preferred":[
         "Humacao"
     ],
+    "name:fas_x_preferred":[
+        "\u0647\u0648\u0645\u0627\u06a9\u0627\u0626\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Humacao"
+    ],
+    "name:gle_x_preferred":[
         "Humacao"
     ],
     "name:heb_x_preferred":[
@@ -48,6 +57,9 @@
     "name:jpn_x_preferred":[
         "\u30a6\u30de\u30ab\u30aa"
     ],
+    "name:lld_x_preferred":[
+        "Humacao"
+    ],
     "name:nld_x_preferred":[
         "Humacao"
     ],
@@ -55,6 +67,9 @@
         "Humacao"
     ],
     "name:por_x_preferred":[
+        "Humacao"
+    ],
+    "name:ron_x_preferred":[
         "Humacao"
     ],
     "name:rus_x_preferred":[
@@ -67,6 +82,9 @@
         "\u0423\u043c\u0430\u043a\u0430\u043e"
     ],
     "name:srp_x_variant":[
+        "Humacao"
+    ],
+    "name:szl_x_preferred":[
         "Humacao"
     ],
     "name:ukr_x_preferred":[
@@ -130,7 +148,7 @@
         }
     ],
     "wof:id":101919245,
-    "wof:lastmodified":1566600318,
+    "wof:lastmodified":1690855887,
     "wof:name":"Humacao",
     "wof:parent_id":102080351,
     "wof:placetype":"locality",

--- a/data/101/919/251/101919251.geojson
+++ b/data/101/919/251/101919251.geojson
@@ -29,7 +29,13 @@
     "name:eng_x_preferred":[
         "Bajandas"
     ],
+    "name:lld_x_preferred":[
+        "Bajandas"
+    ],
     "name:nld_x_preferred":[
+        "Bajandas"
+    ],
+    "name:spa_x_preferred":[
         "Bajandas"
     ],
     "name:srp_x_preferred":[
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":101919251,
-    "wof:lastmodified":1566600322,
+    "wof:lastmodified":1690855892,
     "wof:name":"Bajandas",
     "wof:parent_id":102080351,
     "wof:placetype":"locality",

--- a/data/101/919/253/101919253.geojson
+++ b/data/101/919/253/101919253.geojson
@@ -29,10 +29,19 @@
     "name:cat_x_preferred":[
         "Jayuya"
     ],
+    "name:deu_x_preferred":[
+        "Jayuya"
+    ],
     "name:eng_x_preferred":[
         "Jayuya"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u0648\u06cc\u0648\u06cc\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Jayuya"
+    ],
+    "name:gle_x_preferred":[
         "Jayuya"
     ],
     "name:heb_x_preferred":[
@@ -47,11 +56,17 @@
     "name:jpn_x_preferred":[
         "\u30b8\u30e3\u30e6\u30e4"
     ],
+    "name:lld_x_preferred":[
+        "Jayuya"
+    ],
     "name:nld_x_preferred":[
         "Jayuya"
     ],
     "name:por_x_preferred":[
         "Jayuya"
+    ],
+    "name:rus_x_preferred":[
+        "\u0425\u0430\u044e\u044f"
     ],
     "name:spa_x_preferred":[
         "Jayuya"
@@ -143,7 +158,7 @@
         }
     ],
     "wof:id":101919253,
-    "wof:lastmodified":1566600332,
+    "wof:lastmodified":1690855903,
     "wof:name":"Jayuya",
     "wof:parent_id":102080405,
     "wof:placetype":"locality",

--- a/data/101/919/255/101919255.geojson
+++ b/data/101/919/255/101919255.geojson
@@ -38,7 +38,16 @@
     "name:epo_x_preferred":[
         "Rivero Granda"
     ],
+    "name:fas_x_preferred":[
+        "\u0631\u06cc\u0648 \u06af\u0631\u0627\u0646\u062f"
+    ],
     "name:fra_x_preferred":[
+        "R\u00edo Grande"
+    ],
+    "name:gle_x_preferred":[
+        "R\u00edo Grande"
+    ],
+    "name:hun_x_preferred":[
         "R\u00edo Grande"
     ],
     "name:ita_x_preferred":[
@@ -50,11 +59,17 @@
     "name:nld_x_preferred":[
         "R\u00edo Grande"
     ],
+    "name:nob_x_preferred":[
+        "R\u00edo Grande"
+    ],
     "name:pol_x_preferred":[
         "R\u00edo Grande"
     ],
     "name:por_x_preferred":[
         "R\u00edo Grande"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u0438\u043e-\u0413\u0440\u0430\u043d\u0434\u0435"
     ],
     "name:spa_x_preferred":[
         "R\u00edo Grande"
@@ -120,7 +135,7 @@
         }
     ],
     "wof:id":101919255,
-    "wof:lastmodified":1566600334,
+    "wof:lastmodified":1690855905,
     "wof:name":"R\u00edo Grande",
     "wof:parent_id":102080399,
     "wof:placetype":"locality",

--- a/data/101/919/259/101919259.geojson
+++ b/data/101/919/259/101919259.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "La Dolores"
     ],
+    "name:lld_x_preferred":[
+        "La Dolores"
+    ],
     "name:nld_x_preferred":[
         "La Dolores"
     ],
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101919259,
-    "wof:lastmodified":1566600320,
+    "wof:lastmodified":1690855889,
     "wof:name":"La Dolores",
     "wof:parent_id":102080399,
     "wof:placetype":"locality",

--- a/data/101/919/265/101919265.geojson
+++ b/data/101/919/265/101919265.geojson
@@ -32,10 +32,19 @@
     "name:ceb_x_preferred":[
         "Hormigueros"
     ],
+    "name:deu_x_preferred":[
+        "Hormigueros"
+    ],
     "name:eng_x_preferred":[
         "Hormigueros"
     ],
+    "name:fas_x_preferred":[
+        "\u0647\u0648\u0631\u0645\u06cc\u06af\u0648\u0626\u0631\u0648\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Hormigueros"
+    ],
+    "name:gle_x_preferred":[
         "Hormigueros"
     ],
     "name:hbs_x_preferred":[
@@ -46,6 +55,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30aa\u30eb\u30df\u30b0\u30a8\u30ed\u30b9"
+    ],
+    "name:lld_x_preferred":[
+        "Hormigueros"
     ],
     "name:nld_x_preferred":[
         "Hormigueros"
@@ -150,7 +162,7 @@
         }
     ],
     "wof:id":101919265,
-    "wof:lastmodified":1566600333,
+    "wof:lastmodified":1690855904,
     "wof:name":"Hormigueros",
     "wof:parent_id":102080407,
     "wof:placetype":"locality",

--- a/data/101/919/275/101919275.geojson
+++ b/data/101/919/275/101919275.geojson
@@ -32,10 +32,22 @@
     "name:ceb_x_preferred":[
         "Hatillo"
     ],
+    "name:deu_x_preferred":[
+        "Hatillo"
+    ],
     "name:eng_x_preferred":[
         "Hatillo"
     ],
+    "name:epo_x_preferred":[
+        "Hatillo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0647\u0627\u062a\u06cc\u0644\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Hatillo"
+    ],
+    "name:gle_x_preferred":[
         "Hatillo"
     ],
     "name:hbs_x_preferred":[
@@ -47,11 +59,17 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30c6\u30a3\u30fc\u30b8\u30e7"
     ],
+    "name:lld_x_preferred":[
+        "Hatillo"
+    ],
     "name:nld_x_preferred":[
         "Hatillo"
     ],
     "name:por_x_preferred":[
         "Hatillo"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0442\u0438\u043b\u044c\u043e"
     ],
     "name:spa_x_preferred":[
         "Hatillo"
@@ -79,6 +97,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u63d0\u7d04"
+    ],
+    "name:zho_x_variant":[
+        "\u963f\u8482\u7ea6"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -148,7 +169,7 @@
         }
     ],
     "wof:id":101919275,
-    "wof:lastmodified":1566600320,
+    "wof:lastmodified":1690855888,
     "wof:name":"Hatillo",
     "wof:parent_id":102080381,
     "wof:placetype":"locality",

--- a/data/101/919/277/101919277.geojson
+++ b/data/101/919/277/101919277.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:azb_x_preferred":[
+        "\u0627\u06cc\u0633\u0626\u06cc\u0628\u0644\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u0987\u09b8\u09be\u09ac\u09c7\u09b2\u09be"
     ],
@@ -30,6 +33,9 @@
         "Isabela"
     ],
     "name:dan_x_preferred":[
+        "Isabela"
+    ],
+    "name:deu_x_preferred":[
         "Isabela"
     ],
     "name:eng_x_preferred":[
@@ -47,6 +53,9 @@
     "name:fra_x_preferred":[
         "Isabela"
     ],
+    "name:gle_x_preferred":[
+        "Isabela"
+    ],
     "name:ita_x_preferred":[
         "Isabela"
     ],
@@ -54,6 +63,9 @@
         "\u30a4\u30b5\u30d9\u30e9"
     ],
     "name:lit_x_preferred":[
+        "Isabela"
+    ],
+    "name:lld_x_preferred":[
         "Isabela"
     ],
     "name:nld_x_preferred":[
@@ -64,6 +76,9 @@
     ],
     "name:por_x_preferred":[
         "Isabela"
+    ],
+    "name:rus_x_preferred":[
+        "\u0418\u0441\u0430\u0431\u0435\u043b\u0430"
     ],
     "name:spa_x_preferred":[
         "Isabela"
@@ -86,6 +101,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4f0a\u85a9\u8c9d\u62c9"
+    ],
+    "name:zho_x_variant":[
+        "\u4f0a\u838e\u8d1d\u62c9"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -153,7 +171,7 @@
         }
     ],
     "wof:id":101919277,
-    "wof:lastmodified":1636502704,
+    "wof:lastmodified":1690855899,
     "wof:name":"Isabela",
     "wof:parent_id":102080383,
     "wof:placetype":"locality",

--- a/data/101/919/283/101919283.geojson
+++ b/data/101/919/283/101919283.geojson
@@ -38,6 +38,12 @@
     "name:nld_x_preferred":[
         "San Antonio"
     ],
+    "name:spa_x_preferred":[
+        "San Antonio"
+    ],
+    "name:srp_x_preferred":[
+        "\u0421\u0430\u043d \u0410\u043d\u0442\u043e\u043d\u0438\u043e"
+    ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
     "qs:a1_lc":"72",
@@ -102,7 +108,7 @@
         }
     ],
     "wof:id":101919283,
-    "wof:lastmodified":1636502703,
+    "wof:lastmodified":1690855898,
     "wof:name":"San Antonio",
     "wof:parent_id":102080417,
     "wof:placetype":"locality",

--- a/data/101/919/287/101919287.geojson
+++ b/data/101/919/287/101919287.geojson
@@ -26,6 +26,9 @@
     "name:ara_x_preferred":[
         "\u06a9\u0648\u0644\u064a\u0628\u0631\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u06a9\u0648\u0644\u064a\u0628\u0631\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u041a\u0443\u043b\u0435\u0431\u0440\u0430"
     ],
@@ -50,10 +53,22 @@
     "name:eng_x_preferred":[
         "Culebra"
     ],
+    "name:epo_x_preferred":[
+        "Culebra"
+    ],
     "name:est_x_preferred":[
         "Culebra"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u0644\u0628\u0631\u0627"
+    ],
+    "name:fin_x_preferred":[
+        "Culebra"
+    ],
     "name:fra_x_preferred":[
+        "Culebra"
+    ],
+    "name:gle_x_preferred":[
         "Culebra"
     ],
     "name:hrv_x_preferred":[
@@ -67,6 +82,9 @@
     ],
     "name:lit_x_preferred":[
         "Kulebra"
+    ],
+    "name:lld_x_preferred":[
+        "Culebra"
     ],
     "name:nld_x_preferred":[
         "Culebra"
@@ -183,7 +201,7 @@
         }
     ],
     "wof:id":101919287,
-    "wof:lastmodified":1566600318,
+    "wof:lastmodified":1690855886,
     "wof:name":"Culebra",
     "wof:parent_id":102080273,
     "wof:placetype":"locality",

--- a/data/101/919/289/101919289.geojson
+++ b/data/101/919/289/101919289.geojson
@@ -29,8 +29,17 @@
     "name:eng_x_preferred":[
         "Rio Lajas"
     ],
+    "name:eng_x_variant":[
+        "R\u00edo Lajas"
+    ],
     "name:nld_x_preferred":[
         "Rio Lajas"
+    ],
+    "name:spa_x_preferred":[
+        "R\u00edo Lajas"
+    ],
+    "name:vec_x_preferred":[
+        "R\u00edo Lajas"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":101919289,
-    "wof:lastmodified":1566600318,
+    "wof:lastmodified":1690855887,
     "wof:name":"R\u00edo Lajas",
     "wof:parent_id":102080417,
     "wof:placetype":"locality",

--- a/data/101/919/291/101919291.geojson
+++ b/data/101/919/291/101919291.geojson
@@ -38,7 +38,13 @@
     "name:eng_x_preferred":[
         "Dorado"
     ],
+    "name:fas_x_preferred":[
+        "\u062f\u0648\u0631\u0627\u062f\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Dorado"
+    ],
+    "name:gle_x_preferred":[
         "Dorado"
     ],
     "name:hbs_x_preferred":[
@@ -50,6 +56,9 @@
     "name:jpn_x_preferred":[
         "\u30c9\u30e9\u30c9"
     ],
+    "name:lld_x_preferred":[
+        "Dorado"
+    ],
     "name:nld_x_preferred":[
         "Dorado"
     ],
@@ -58,6 +67,9 @@
     ],
     "name:por_x_preferred":[
         "Dorado"
+    ],
+    "name:rus_x_preferred":[
+        "\u0414\u043e\u0440\u0430\u0434\u043e"
     ],
     "name:spa_x_preferred":[
         "Dorado"
@@ -148,7 +160,7 @@
         }
     ],
     "wof:id":101919291,
-    "wof:lastmodified":1566600333,
+    "wof:lastmodified":1690855904,
     "wof:name":"Dorado",
     "wof:parent_id":102080417,
     "wof:placetype":"locality",

--- a/data/101/919/293/101919293.geojson
+++ b/data/101/919/293/101919293.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":8.0,
+    "name:azb_x_preferred":[
+        "\u0642\u0648\u0627\u06cc\u0646\u0627\u0628\u0648"
+    ],
     "name:bpy_x_preferred":[
         "\u0997\u09c1\u09f1\u09be\u09af\u09bc\u09a8\u09be\u09ac\u09cb"
     ],
@@ -47,6 +50,9 @@
     "name:fra_x_preferred":[
         "Guaynabo"
     ],
+    "name:gle_x_preferred":[
+        "Guaynabo"
+    ],
     "name:ita_x_preferred":[
         "Guaynabo"
     ],
@@ -55,6 +61,9 @@
     ],
     "name:lit_x_preferred":[
         "Guainabas"
+    ],
+    "name:lld_x_preferred":[
+        "Guaynabo"
     ],
     "name:mkd_x_preferred":[
         "\u0413\u0443\u0430\u0458\u043d\u0430\u0431\u043e"
@@ -68,6 +77,9 @@
     "name:por_x_preferred":[
         "Guaynabo"
     ],
+    "name:rus_x_preferred":[
+        "\u0413\u0443\u0430\u0439\u043d\u0430\u0431\u043e"
+    ],
     "name:sco_x_preferred":[
         "Guaynabo"
     ],
@@ -75,6 +87,12 @@
         "Guaynabo"
     ],
     "name:srp_x_preferred":[
+        "Guaynabo"
+    ],
+    "name:swa_x_preferred":[
+        "Guaynabo"
+    ],
+    "name:swe_x_preferred":[
         "Guaynabo"
     ],
     "name:ukr_x_preferred":[
@@ -158,7 +176,7 @@
         }
     ],
     "wof:id":101919293,
-    "wof:lastmodified":1566600322,
+    "wof:lastmodified":1690855891,
     "wof:name":"Guaynabo",
     "wof:parent_id":102080365,
     "wof:placetype":"locality",

--- a/data/101/919/295/101919295.geojson
+++ b/data/101/919/295/101919295.geojson
@@ -26,19 +26,34 @@
     "name:azb_x_preferred":[
         "\u06a9\u0648\u0626\u0628\u0631\u0627\u062f\u06cc\u0644\u0627\u0633"
     ],
+    "name:bpy_x_preferred":[
+        "\u0995\u09c1\u09af\u09bc\u09c7\u09ac\u09cd\u09b0\u09be\u09a1\u09bf\u09b2\u09cd\u09b2\u09be\u09b8"
+    ],
     "name:cat_x_preferred":[
         "Quebradillas"
     ],
     "name:ceb_x_preferred":[
         "Quebradillas"
     ],
+    "name:ceb_x_variant":[
+        "Quebradillas Municipio"
+    ],
+    "name:deu_x_preferred":[
+        "Quebradillas"
+    ],
     "name:eng_x_preferred":[
+        "Quebradillas"
+    ],
+    "name:epo_x_preferred":[
         "Quebradillas"
     ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0626\u0628\u0631\u0627\u062f\u06cc\u0644\u0627\u0633"
     ],
     "name:fra_x_preferred":[
+        "Quebradillas"
+    ],
+    "name:gle_x_preferred":[
         "Quebradillas"
     ],
     "name:hbs_x_preferred":[
@@ -50,11 +65,20 @@
     "name:jpn_x_preferred":[
         "\u30b1\u30d6\u30e9\u30c7\u30a3\u30fc\u30b8\u30e3\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Quebradillas"
+    ],
     "name:nld_x_preferred":[
+        "Quebradillas"
+    ],
+    "name:pol_x_preferred":[
         "Quebradillas"
     ],
     "name:por_x_preferred":[
         "Quebradillas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u0435\u0431\u0440\u0430\u0434\u0438\u043b\u044c\u044f\u0441"
     ],
     "name:spa_x_preferred":[
         "Quebradillas"
@@ -144,7 +168,7 @@
         }
     ],
     "wof:id":101919295,
-    "wof:lastmodified":1566600321,
+    "wof:lastmodified":1690855889,
     "wof:name":"Quebradillas",
     "wof:parent_id":102080325,
     "wof:placetype":"locality",

--- a/data/101/919/305/101919305.geojson
+++ b/data/101/919/305/101919305.geojson
@@ -23,6 +23,9 @@
     "name:afr_x_preferred":[
         "San Antonio"
     ],
+    "name:aka_x_preferred":[
+        "San Antonio"
+    ],
     "name:amh_x_preferred":[
         "\u1233\u1295 \u12a0\u1295\u1276\u1292\u12ee"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:arg_x_preferred":[
         "San Antonio"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u0627\u0646\u0637\u0648\u0646\u064a\u0648"
     ],
     "name:ast_x_preferred":[
         "San Antonio"
@@ -71,10 +77,16 @@
     "name:che_x_preferred":[
         "\u0421\u0430\u043d-\u0410\u043d\u0442\u043e\u043d\u0438\u043e"
     ],
+    "name:ckb_x_preferred":[
+        "\u0633\u0627\u0646 \u0626\u06d5\u0646\u062a\u06c6\u0646\u06cc\u06c6"
+    ],
     "name:cor_x_preferred":[
         "San Antonio"
     ],
     "name:cym_x_preferred":[
+        "San Antonio"
+    ],
+    "name:dag_x_preferred":[
         "San Antonio"
     ],
     "name:dan_x_preferred":[
@@ -131,6 +143,9 @@
     "name:glg_x_preferred":[
         "San Antonio"
     ],
+    "name:grn_x_preferred":[
+        "San Antonio"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8 \u0a8f\u0aa8\u0acd\u0a9f\u0acb\u0aa8\u0abf\u0aaf\u0acb"
     ],
@@ -155,6 +170,12 @@
     "name:hye_x_preferred":[
         "\u054d\u0561\u0576 \u0531\u0576\u057f\u0578\u0576\u056b\u0578"
     ],
+    "name:ido_x_preferred":[
+        "San Antonio"
+    ],
+    "name:ile_x_preferred":[
+        "San Antonio"
+    ],
     "name:ilo_x_preferred":[
         "San Antonio"
     ],
@@ -176,6 +197,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30a2\u30f3\u30c8\u30cb\u30aa"
     ],
+    "name:jpn_x_variant":[
+        "\u30b5\u30f3\u30fb\u30a2\u30f3\u30c8\u30cb\u30aa"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0ccd\u0caf\u0cbe\u0ca8\u0ccd \u0c86\u0c82\u0c9f\u0ccb\u0ca8\u0cbf\u0caf\u0ccb"
     ],
@@ -191,11 +215,17 @@
     "name:kor_x_preferred":[
         "\uc0cc\uc548\ud1a0\ub2c8\uc624"
     ],
+    "name:kur_x_preferred":[
+        "San Antonio"
+    ],
     "name:lad_x_preferred":[
         "San Antonio"
     ],
     "name:lat_x_preferred":[
         "Sanctus Antonius"
+    ],
+    "name:lat_x_variant":[
+        "Antoniopolis"
     ],
     "name:lav_x_preferred":[
         "Sanantonio"
@@ -208,6 +238,9 @@
     ],
     "name:lit_x_preferred":[
         "San Antonijas"
+    ],
+    "name:lld_x_preferred":[
+        "San Antonio"
     ],
     "name:ltz_x_preferred":[
         "San Antonio"
@@ -233,11 +266,17 @@
     "name:msa_x_preferred":[
         "San Antonio"
     ],
+    "name:mya_x_preferred":[
+        "\u1006\u1014\u103a \u1021\u1014\u103a\u1010\u102d\u102f\u1014\u102e\u101a\u102d\u102f"
+    ],
     "name:nah_x_preferred":[
         "San Antonio"
     ],
     "name:nan_x_preferred":[
         "San Antonio"
+    ],
+    "name:nav_x_preferred":[
+        "Kin Hal\u00e1n\u00edtah"
     ],
     "name:nep_x_preferred":[
         "\u0938\u093e\u0928 \u0906\u0928\u094d\u091f\u094b\u0928\u093f\u092f\u094b"
@@ -297,6 +336,9 @@
         "San Antonio"
     ],
     "name:slv_x_preferred":[
+        "San Antonio"
+    ],
+    "name:smn_x_preferred":[
         "San Antonio"
     ],
     "name:som_x_preferred":[
@@ -377,6 +419,9 @@
     "name:war_x_preferred":[
         "San Antonio"
     ],
+    "name:wuu_x_preferred":[
+        "\u5723\u5b89\u4e1c\u5c3c\u5965"
+    ],
     "name:xmf_x_preferred":[
         "\u10e1\u10d0\u10dc-\u10d0\u10dc\u10d7\u10dd\u10dc\u10d8\u10dd"
     ],
@@ -435,7 +480,7 @@
         }
     ],
     "wof:id":101919305,
-    "wof:lastmodified":1566600329,
+    "wof:lastmodified":1690855897,
     "wof:name":"San Antonio",
     "wof:parent_id":102080325,
     "wof:placetype":"locality",

--- a/data/101/919/309/101919309.geojson
+++ b/data/101/919/309/101919309.geojson
@@ -44,7 +44,16 @@
     "name:eng_x_preferred":[
         "Guayama"
     ],
+    "name:epo_x_preferred":[
+        "Guayama"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0627\u06cc\u0627\u0645\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Guayama"
+    ],
+    "name:gle_x_preferred":[
         "Guayama"
     ],
     "name:hye_x_preferred":[
@@ -55,6 +64,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b0\u30a2\u30e4\u30de"
+    ],
+    "name:lld_x_preferred":[
+        "Guayama"
     ],
     "name:nld_x_preferred":[
         "Guayama"
@@ -165,7 +177,7 @@
         }
     ],
     "wof:id":101919309,
-    "wof:lastmodified":1566600315,
+    "wof:lastmodified":1690855883,
     "wof:name":"Guayama",
     "wof:parent_id":102080373,
     "wof:placetype":"locality",

--- a/data/101/919/313/101919313.geojson
+++ b/data/101/919/313/101919313.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:azb_x_preferred":[
+        "\u0648\u0642\u0627 \u0622\u0644\u062a\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u09ad\u09c7\u0997\u09be \u0986\u09b2\u099f\u09be"
     ],
@@ -30,6 +33,9 @@
         "Vega Alta"
     ],
     "name:ceb_x_preferred":[
+        "Vega Alta"
+    ],
+    "name:deu_x_preferred":[
         "Vega Alta"
     ],
     "name:eng_x_preferred":[
@@ -44,17 +50,29 @@
     "name:fra_x_preferred":[
         "Vega Alta"
     ],
+    "name:gle_x_preferred":[
+        "Vega Alta"
+    ],
     "name:ita_x_preferred":[
         "Vega Alta"
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30ac\u30fb\u30a2\u30eb\u30bf"
     ],
+    "name:lld_x_preferred":[
+        "Vega Alta"
+    ],
     "name:nld_x_preferred":[
         "Vega Alta"
     ],
     "name:pol_x_preferred":[
         "Vega Alta"
+    ],
+    "name:por_x_preferred":[
+        "Vega Alta"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u0435\u0433\u0430-\u0410\u043b\u044c\u0442\u0430"
     ],
     "name:scn_x_preferred":[
         "Vega Alta"
@@ -149,7 +167,7 @@
         }
     ],
     "wof:id":101919313,
-    "wof:lastmodified":1566600326,
+    "wof:lastmodified":1690855895,
     "wof:name":"Vega Alta",
     "wof:parent_id":102080413,
     "wof:placetype":"locality",

--- a/data/101/919/329/101919329.geojson
+++ b/data/101/919/329/101919329.geojson
@@ -32,10 +32,19 @@
     "name:ceb_x_preferred":[
         "Sabana Grande"
     ],
+    "name:deu_x_preferred":[
+        "Sabana Grande"
+    ],
     "name:eng_x_preferred":[
         "Sabana Grande"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0627\u0628\u0627\u06cc\u0627 \u06af\u0631\u0646\u062f\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Sabana Grande"
+    ],
+    "name:gle_x_preferred":[
         "Sabana Grande"
     ],
     "name:ita_x_preferred":[
@@ -43,6 +52,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30d0\u30ca\u30fb\u30b0\u30e9\u30f3\u30c7"
+    ],
+    "name:lld_x_preferred":[
+        "Sabana Grande"
     ],
     "name:nld_x_preferred":[
         "Sabana Grande"
@@ -52,6 +64,9 @@
     ],
     "name:por_x_preferred":[
         "Sabana Grande"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u0431\u0430\u043d\u0430-\u0413\u0440\u0430\u043d\u0434\u0435"
     ],
     "name:spa_x_preferred":[
         "Sabana Grande"
@@ -140,7 +155,7 @@
         }
     ],
     "wof:id":101919329,
-    "wof:lastmodified":1566600335,
+    "wof:lastmodified":1690855906,
     "wof:name":"Sabana Grande",
     "wof:parent_id":102080395,
     "wof:placetype":"locality",

--- a/data/101/919/331/101919331.geojson
+++ b/data/101/919/331/101919331.geojson
@@ -32,13 +32,22 @@
     "name:ceb_x_preferred":[
         "Las Piedras"
     ],
+    "name:deu_x_preferred":[
+        "Las Piedras"
+    ],
     "name:eng_x_preferred":[
         "Las Piedras"
     ],
     "name:epo_x_preferred":[
         "La \u015ctonoj"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0627\u0633 \u067e\u06cc\u062f\u0631\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Las Piedras"
+    ],
+    "name:gle_x_preferred":[
         "Las Piedras"
     ],
     "name:ita_x_preferred":[
@@ -47,11 +56,20 @@
     "name:jpn_x_preferred":[
         "\u30e9\u30b9\u30fb\u30d4\u30a8\u30c9\u30e9\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Las Piedras"
+    ],
     "name:nld_x_preferred":[
+        "Las Piedras"
+    ],
+    "name:pol_x_preferred":[
         "Las Piedras"
     ],
     "name:por_x_preferred":[
         "Las Piedras"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u0430\u0441-\u041f\u044c\u0435\u0434\u0440\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Las Piedras"
@@ -143,7 +161,7 @@
         }
     ],
     "wof:id":101919331,
-    "wof:lastmodified":1566600315,
+    "wof:lastmodified":1690855884,
     "wof:name":"Las Piedras",
     "wof:parent_id":102080391,
     "wof:placetype":"locality",

--- a/data/101/919/337/101919337.geojson
+++ b/data/101/919/337/101919337.geojson
@@ -32,10 +32,19 @@
     "name:deu_x_preferred":[
         "Lo\u00edza"
     ],
+    "name:ell_x_preferred":[
+        "\u039b\u03bf\u0390\u03c3\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Lo\u00edza"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0648\u06cc\u0632\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Lo\u00edza"
+    ],
+    "name:gle_x_preferred":[
         "Lo\u00edza"
     ],
     "name:ita_x_preferred":[
@@ -43,6 +52,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ed\u30a4\u30b5"
+    ],
+    "name:lld_x_preferred":[
+        "Lo\u00edza"
     ],
     "name:nld_x_preferred":[
         "Lo\u00edza"
@@ -52,6 +64,9 @@
     ],
     "name:por_x_preferred":[
         "Lo\u00edza"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u043e\u0438\u0441\u0430"
     ],
     "name:spa_x_preferred":[
         "Lo\u00edza"
@@ -117,7 +132,7 @@
         }
     ],
     "wof:id":101919337,
-    "wof:lastmodified":1566600316,
+    "wof:lastmodified":1690855884,
     "wof:name":"Lo\u00edza",
     "wof:parent_id":102080363,
     "wof:placetype":"locality",

--- a/data/101/919/343/101919343.geojson
+++ b/data/101/919/343/101919343.geojson
@@ -20,10 +20,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:ceb_x_preferred":[
+        "Su\u00e1rez"
+    ],
     "name:eng_x_preferred":[
         "Su\u00e1rez"
     ],
     "name:nld_x_preferred":[
+        "Su\u00e1rez"
+    ],
+    "name:spa_x_preferred":[
         "Su\u00e1rez"
     ],
     "name:srp_x_preferred":[
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":101919343,
-    "wof:lastmodified":1566600337,
+    "wof:lastmodified":1690855908,
     "wof:name":"Su\u00e1rez",
     "wof:parent_id":102080363,
     "wof:placetype":"locality",

--- a/data/101/919/349/101919349.geojson
+++ b/data/101/919/349/101919349.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062e\u0648\u0627\u0646\u0627 \u062f\u064a\u0627\u0632"
+    ],
     "name:bpy_x_preferred":[
         "\u099c\u09c1\u09af\u09bc\u09be\u09a8\u09be \u09a1\u09bf\u09af\u09bc\u09be\u099c"
     ],
@@ -33,10 +36,19 @@
     "name:ces_x_preferred":[
         "Juana D\u00edaz"
     ],
+    "name:deu_x_preferred":[
+        "Juana D\u00edaz"
+    ],
     "name:eng_x_preferred":[
         "Juana D\u00edaz"
     ],
+    "name:fas_x_preferred":[
+        "\u062e\u0648\u0627\u0646\u0627 \u062f\u06cc\u0627\u0632"
+    ],
     "name:fra_x_preferred":[
+        "Juana D\u00edaz"
+    ],
+    "name:gle_x_preferred":[
         "Juana D\u00edaz"
     ],
     "name:hbs_x_preferred":[
@@ -56,6 +68,9 @@
     ],
     "name:por_x_preferred":[
         "Juana D\u00edaz"
+    ],
+    "name:rus_x_preferred":[
+        "\u0425\u0443\u0430\u043d\u0430-\u0414\u0438\u0430\u0441"
     ],
     "name:slk_x_preferred":[
         "Juana D\u00edaz"
@@ -131,7 +146,7 @@
         }
     ],
     "wof:id":101919349,
-    "wof:lastmodified":1566600326,
+    "wof:lastmodified":1690855894,
     "wof:name":"Juana D\u00edaz",
     "wof:parent_id":102080415,
     "wof:placetype":"locality",

--- a/data/101/919/363/101919363.geojson
+++ b/data/101/919/363/101919363.geojson
@@ -32,10 +32,22 @@
     "name:ceb_x_preferred":[
         "Gurabo"
     ],
+    "name:deu_x_preferred":[
+        "Gurabo"
+    ],
     "name:eng_x_preferred":[
         "Gurabo"
     ],
+    "name:epo_x_preferred":[
+        "Gurabo"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0631\u0627\u0628\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Gurabo"
+    ],
+    "name:gle_x_preferred":[
         "Gurabo"
     ],
     "name:hbs_x_preferred":[
@@ -47,6 +59,9 @@
     "name:jpn_x_preferred":[
         "\u30b0\u30e9\u30fc\u30dc"
     ],
+    "name:lld_x_preferred":[
+        "Gurabo"
+    ],
     "name:nld_x_preferred":[
         "Gurabo"
     ],
@@ -56,6 +71,9 @@
     "name:por_x_preferred":[
         "Gurabo"
     ],
+    "name:rus_x_preferred":[
+        "\u0413\u0443\u0440\u0430\u0431\u043e"
+    ],
     "name:spa_x_preferred":[
         "Gurabo"
     ],
@@ -63,6 +81,9 @@
         "\u0413\u0443\u0440\u0430\u0431\u043e"
     ],
     "name:srp_x_variant":[
+        "Gurabo"
+    ],
+    "name:swe_x_preferred":[
         "Gurabo"
     ],
     "name:ukr_x_preferred":[
@@ -148,7 +169,7 @@
         }
     ],
     "wof:id":101919363,
-    "wof:lastmodified":1566600317,
+    "wof:lastmodified":1690855885,
     "wof:name":"Gurabo",
     "wof:parent_id":102080435,
     "wof:placetype":"locality",

--- a/data/101/919/369/101919369.geojson
+++ b/data/101/919/369/101919369.geojson
@@ -32,10 +32,22 @@
     "name:ceb_x_preferred":[
         "Guayanilla"
     ],
+    "name:deu_x_preferred":[
+        "Guayanilla"
+    ],
     "name:eng_x_preferred":[
         "Guayanilla"
     ],
+    "name:epo_x_preferred":[
+        "Guayanilla"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0627\u06cc\u0627\u0646\u06cc\u0644\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Guayanilla"
+    ],
+    "name:gle_x_preferred":[
         "Guayanilla"
     ],
     "name:hbs_x_preferred":[
@@ -47,11 +59,20 @@
     "name:jpn_x_preferred":[
         "\u30b0\u30a2\u30e4\u30cb\u30e9"
     ],
+    "name:lld_x_preferred":[
+        "Guayanilla"
+    ],
     "name:nld_x_preferred":[
+        "Guayanilla"
+    ],
+    "name:pol_x_preferred":[
         "Guayanilla"
     ],
     "name:por_x_preferred":[
         "Guayanilla"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0443\u0430\u044f\u043d\u0438\u043b\u044c\u044f"
     ],
     "name:spa_x_preferred":[
         "Guayanilla"
@@ -147,7 +168,7 @@
         }
     ],
     "wof:id":101919369,
-    "wof:lastmodified":1566600328,
+    "wof:lastmodified":1690855896,
     "wof:name":"Guayanilla",
     "wof:parent_id":102080297,
     "wof:placetype":"locality",

--- a/data/101/919/377/101919377.geojson
+++ b/data/101/919/377/101919377.geojson
@@ -35,11 +35,17 @@
     "name:eng_x_preferred":[
         "Manat\u00ed"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0646\u0627\u062a\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Manat\u00ed"
     ],
     "name:fry_x_preferred":[
         "Manati"
+    ],
+    "name:gle_x_preferred":[
+        "Manat\u00ed"
     ],
     "name:ita_x_preferred":[
         "Manat\u00ed"
@@ -52,6 +58,12 @@
     ],
     "name:pol_x_preferred":[
         "Manat\u00ed"
+    ],
+    "name:por_x_preferred":[
+        "Manat\u00ed"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u043d\u0430\u0442\u0438"
     ],
     "name:spa_x_preferred":[
         "Manat\u00ed"
@@ -120,7 +132,7 @@
         }
     ],
     "wof:id":101919377,
-    "wof:lastmodified":1566600324,
+    "wof:lastmodified":1690855893,
     "wof:name":"Manat\u00ed",
     "wof:parent_id":102080271,
     "wof:placetype":"locality",

--- a/data/101/919/383/101919383.geojson
+++ b/data/101/919/383/101919383.geojson
@@ -35,10 +35,19 @@
     "name:ceb_x_preferred":[
         "Naranjito"
     ],
+    "name:deu_x_preferred":[
+        "Naranjito"
+    ],
     "name:eng_x_preferred":[
         "Naranjito"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u0631\u0646\u062c\u06cc\u062a\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Naranjito"
+    ],
+    "name:gle_x_preferred":[
         "Naranjito"
     ],
     "name:hbs_x_preferred":[
@@ -50,8 +59,17 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30e9\u30f3\u30d2\u30fc\u30c8"
     ],
+    "name:lld_x_preferred":[
+        "Naranjito"
+    ],
     "name:nld_x_preferred":[
         "Naranjito"
+    ],
+    "name:por_x_preferred":[
+        "Naranjito"
+    ],
+    "name:rus_x_preferred":[
+        "\u041d\u0430\u0440\u0430\u043d\u0445\u0438\u0442\u043e"
     ],
     "name:spa_x_preferred":[
         "Naranjito"
@@ -146,7 +164,7 @@
         }
     ],
     "wof:id":101919383,
-    "wof:lastmodified":1566600324,
+    "wof:lastmodified":1690855893,
     "wof:name":"Naranjito",
     "wof:parent_id":102080303,
     "wof:placetype":"locality",

--- a/data/101/919/385/101919385.geojson
+++ b/data/101/919/385/101919385.geojson
@@ -38,7 +38,13 @@
     "name:ceb_x_preferred":[
         "Moca"
     ],
+    "name:ceb_x_variant":[
+        "Moca Municipio"
+    ],
     "name:dan_x_preferred":[
+        "Moca"
+    ],
+    "name:deu_x_preferred":[
         "Moca"
     ],
     "name:ell_x_preferred":[
@@ -47,10 +53,16 @@
     "name:eng_x_preferred":[
         "Moca"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0648\u06a9\u0627"
+    ],
     "name:fin_x_preferred":[
         "Moca"
     ],
     "name:fra_x_preferred":[
+        "Moca"
+    ],
+    "name:gle_x_preferred":[
         "Moca"
     ],
     "name:guj_x_preferred":[
@@ -88,6 +100,9 @@
     ],
     "name:lit_x_preferred":[
         "Moka"
+    ],
+    "name:lld_x_preferred":[
+        "Moca"
     ],
     "name:mar_x_preferred":[
         "\u092e\u094b\u0915\u093e"
@@ -226,7 +241,7 @@
         }
     ],
     "wof:id":101919385,
-    "wof:lastmodified":1636502703,
+    "wof:lastmodified":1690855894,
     "wof:name":"Moca",
     "wof:parent_id":102080423,
     "wof:placetype":"locality",

--- a/data/101/919/395/101919395.geojson
+++ b/data/101/919/395/101919395.geojson
@@ -23,16 +23,28 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:bpy_x_preferred":[
+        "\u09a8\u09be\u0997\u09c1\u09f1\u09be\u09ac\u09cb"
+    ],
     "name:cat_x_preferred":[
         "Naguabo"
     ],
     "name:ceb_x_preferred":[
         "Naguabo"
     ],
+    "name:deu_x_preferred":[
+        "Naguabo"
+    ],
     "name:eng_x_preferred":[
         "Naguabo"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u06af\u0648\u0627\u0628\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Naguabo"
+    ],
+    "name:gle_x_preferred":[
         "Naguabo"
     ],
     "name:ita_x_preferred":[
@@ -44,8 +56,17 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30b0\u30a2\u30dc"
     ],
+    "name:lld_x_preferred":[
+        "Naguabo"
+    ],
     "name:nld_x_preferred":[
         "Nag\u00fcabo"
+    ],
+    "name:pol_x_preferred":[
+        "Naguabo"
+    ],
+    "name:por_x_preferred":[
+        "Naguabo"
     ],
     "name:rus_x_preferred":[
         "\u041d\u0430\u0433\u0443\u0430\u0431\u043e"
@@ -55,6 +76,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041d\u0430\u0433\u0432\u0430\u0431\u043e"
+    ],
+    "name:swe_x_preferred":[
+        "Naguabo"
     ],
     "name:ukr_x_preferred":[
         "\u041d\u0430\u0433\u0443\u0430\u0431\u043e"
@@ -140,7 +164,7 @@
         }
     ],
     "wof:id":101919395,
-    "wof:lastmodified":1566600327,
+    "wof:lastmodified":1690855896,
     "wof:name":"Naguabo",
     "wof:parent_id":102080355,
     "wof:placetype":"locality",

--- a/data/101/919/399/101919399.geojson
+++ b/data/101/919/399/101919399.geojson
@@ -32,6 +32,9 @@
     "name:spa_x_preferred":[
         "R\u00edo Daguao"
     ],
+    "name:vec_x_preferred":[
+        "R\u00edo Daguao"
+    ],
     "qs:a0":"Puerto Rico",
     "qs:a1":"*Puerto Rico",
     "qs:a1_lc":"72",
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101919399,
-    "wof:lastmodified":1566600316,
+    "wof:lastmodified":1690855885,
     "wof:name":"Daguao",
     "wof:parent_id":102080355,
     "wof:placetype":"locality",

--- a/data/101/919/403/101919403.geojson
+++ b/data/101/919/403/101919403.geojson
@@ -23,6 +23,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:azb_x_preferred":[
+        "\u0648\u0642\u0627 \u0628\u0627\u062c\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u09ad\u09c7\u0997\u09be \u09ac\u09be\u099c\u09be"
     ],
@@ -30,6 +33,9 @@
         "Vega Baja"
     ],
     "name:ceb_x_preferred":[
+        "Vega Baja"
+    ],
+    "name:deu_x_preferred":[
         "Vega Baja"
     ],
     "name:eng_x_preferred":[
@@ -44,11 +50,20 @@
     "name:fra_x_preferred":[
         "Vega Baja"
     ],
+    "name:gle_x_preferred":[
+        "Vega Baja"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d5\u05d5\u05d2\u05d4 \u05d1\u05d0\u05d7\u05d4"
+    ],
     "name:ita_x_preferred":[
         "Vega Baja"
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30ac\u30fb\u30d0\u30cf"
+    ],
+    "name:lld_x_preferred":[
+        "Vega Baja"
     ],
     "name:nld_x_preferred":[
         "Vega Baja"
@@ -58,6 +73,9 @@
     ],
     "name:por_x_preferred":[
         "Vega Baja"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u0435\u0433\u0430-\u0411\u0430\u0445\u0430"
     ],
     "name:scn_x_preferred":[
         "Vega Baja"
@@ -152,7 +170,7 @@
         }
     ],
     "wof:id":101919403,
-    "wof:lastmodified":1566600334,
+    "wof:lastmodified":1690855906,
     "wof:name":"Vega Baja",
     "wof:parent_id":102080305,
     "wof:placetype":"locality",

--- a/data/101/919/405/101919405.geojson
+++ b/data/101/919/405/101919405.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:azb_x_preferred":[
+        "\u06cc\u0627\u0648\u06a9\u0648"
+    ],
     "name:bpy_x_preferred":[
         "\u09af\u09bc\u09be\u0989\u0995\u09cb"
     ],
@@ -30,10 +33,22 @@
     "name:ceb_x_preferred":[
         "Yauco"
     ],
+    "name:deu_x_preferred":[
+        "Yauco"
+    ],
     "name:eng_x_preferred":[
         "Yauco"
     ],
+    "name:epo_x_preferred":[
+        "Yauco"
+    ],
+    "name:fas_x_preferred":[
+        "\u06cc\u0627\u0648\u06a9\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Yauco"
+    ],
+    "name:gle_x_preferred":[
         "Yauco"
     ],
     "name:hbs_x_preferred":[
@@ -49,6 +64,9 @@
         "Yauco"
     ],
     "name:pol_x_preferred":[
+        "Yauco"
+    ],
+    "name:por_x_preferred":[
         "Yauco"
     ],
     "name:rus_x_preferred":[
@@ -131,7 +149,7 @@
         }
     ],
     "wof:id":101919405,
-    "wof:lastmodified":1566600332,
+    "wof:lastmodified":1690855903,
     "wof:name":"Yauco",
     "wof:parent_id":102080397,
     "wof:placetype":"locality",

--- a/data/101/919/409/101919409.geojson
+++ b/data/101/919/409/101919409.geojson
@@ -44,11 +44,17 @@
     "name:ita_x_preferred":[
         "Plena"
     ],
+    "name:lld_x_preferred":[
+        "La Plena"
+    ],
     "name:nld_x_preferred":[
         "La Plena"
     ],
     "name:spa_x_preferred":[
         "Plena"
+    ],
+    "name:spa_x_variant":[
+        "La Plena"
     ],
     "name:srp_x_preferred":[
         "\u041b\u0430 \u041f\u043b\u0435\u043d\u0430"
@@ -121,7 +127,7 @@
         }
     ],
     "wof:id":101919409,
-    "wof:lastmodified":1566600322,
+    "wof:lastmodified":1690855891,
     "wof:name":"La Plena",
     "wof:parent_id":102080337,
     "wof:placetype":"locality",

--- a/data/101/919/419/101919419.geojson
+++ b/data/101/919/419/101919419.geojson
@@ -29,7 +29,13 @@
     "name:eng_x_preferred":[
         "Las Ochenta"
     ],
+    "name:lld_x_preferred":[
+        "Las Ochenta"
+    ],
     "name:nld_x_preferred":[
+        "Las Ochenta"
+    ],
+    "name:spa_x_preferred":[
         "Las Ochenta"
     ],
     "name:srp_x_preferred":[
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":101919419,
-    "wof:lastmodified":1566600329,
+    "wof:lastmodified":1690855898,
     "wof:name":"Las Ochenta",
     "wof:parent_id":102080337,
     "wof:placetype":"locality",

--- a/data/101/919/423/101919423.geojson
+++ b/data/101/919/423/101919423.geojson
@@ -35,10 +35,19 @@
     "name:ceb_x_preferred":[
         "Salinas Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Salinas"
+    ],
     "name:eng_x_preferred":[
         "Salinas"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0627\u0644\u06cc\u0646\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Salinas"
+    ],
+    "name:gle_x_preferred":[
         "Salinas"
     ],
     "name:hun_x_preferred":[
@@ -50,7 +59,13 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30ea\u30ca\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Salinas"
+    ],
     "name:nld_x_preferred":[
+        "Salinas"
+    ],
+    "name:pol_x_preferred":[
         "Salinas"
     ],
     "name:por_x_preferred":[
@@ -154,7 +169,7 @@
         }
     ],
     "wof:id":101919423,
-    "wof:lastmodified":1636502702,
+    "wof:lastmodified":1690855888,
     "wof:name":"Salinas",
     "wof:parent_id":102080337,
     "wof:placetype":"locality",

--- a/data/101/919/425/101919425.geojson
+++ b/data/101/919/425/101919425.geojson
@@ -38,6 +38,9 @@
     "name:ang_x_preferred":[
         "V\u00e1squez"
     ],
+    "name:ara_x_preferred":[
+        "\u0641\u0627\u0633\u0643\u064a\u0632"
+    ],
     "name:arg_x_preferred":[
         "V\u00e1squez"
     ],
@@ -283,6 +286,9 @@
     ],
     "name:jbo_x_preferred":[
         "V\u00e1squez"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d0\u30b9\u30b1\u30b9"
     ],
     "name:jut_x_preferred":[
         "V\u00e1squez"
@@ -572,6 +578,9 @@
     "name:srn_x_preferred":[
         "V\u00e1squez"
     ],
+    "name:srp_x_preferred":[
+        "\u0412\u0430\u0441\u043a\u0435\u0437"
+    ],
     "name:srq_x_preferred":[
         "V\u00e1squez"
     ],
@@ -659,6 +668,9 @@
     "name:zea_x_preferred":[
         "V\u00e1squez"
     ],
+    "name:zho_x_preferred":[
+        "\u8d1d\u62c9\u65af\u514b\u65af"
+    ],
     "name:zul_x_preferred":[
         "V\u00e1squez"
     ],
@@ -706,7 +718,7 @@
         }
     ],
     "wof:id":101919425,
-    "wof:lastmodified":1566600318,
+    "wof:lastmodified":1690855886,
     "wof:name":"V\u00e1zquez",
     "wof:parent_id":102080337,
     "wof:placetype":"locality",

--- a/data/101/919/427/101919427.geojson
+++ b/data/101/919/427/101919427.geojson
@@ -32,11 +32,20 @@
     "name:arg_x_preferred":[
         "San Juan"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u062e\u0648\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "San Xuan"
     ],
+    "name:azb_x_preferred":[
+        "\u0633\u0627\u0646 \u062c\u0648\u0627\u0646"
+    ],
     "name:aze_x_preferred":[
         "San Xuan"
+    ],
+    "name:aze_x_variant":[
+        "San-Xuan"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0430\u043d-\u0425\u0443\u0430\u043d"
@@ -98,6 +107,9 @@
     "name:eus_x_preferred":[
         "San Juan de Puerto Rico"
     ],
+    "name:eus_x_variant":[
+        "San Juan"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0627\u0646 \u062e\u0648\u0622\u0646"
     ],
@@ -152,6 +164,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30d5\u30a2\u30f3"
     ],
+    "name:jpn_x_variant":[
+        "\u30b5\u30f3\u30fb\u30d5\u30a2\u30f3"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0ccd\u0caf\u0cbe\u0ca8\u0ccd \u200d\u0c89\u0cb5\u0cbe\u0ca8\u0ccd"
     ],
@@ -170,6 +185,12 @@
     "name:lit_x_preferred":[
         "San Chuanas"
     ],
+    "name:lld_x_preferred":[
+        "San Juan"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d38\u0d3e\u0d7b \u0d39\u0d41\u0d35\u0d3e\u0d7b"
+    ],
     "name:mar_x_preferred":[
         "\u0938\u093e\u0928 \u0939\u0941\u0906\u0928"
     ],
@@ -177,6 +198,9 @@
         "\u0421\u0430\u043d \u0425\u0443\u0430\u043d"
     ],
     "name:mlg_x_preferred":[
+        "San Juan"
+    ],
+    "name:mlt_x_preferred":[
         "San Juan"
     ],
     "name:mon_x_preferred":[
@@ -210,6 +234,9 @@
         "\u0a38\u0a3e\u0a28 \u0a39\u0a41\u0a06\u0a28"
     ],
     "name:pap_x_preferred":[
+        "San Juan"
+    ],
+    "name:pms_x_preferred":[
         "San Juan"
     ],
     "name:pol_x_preferred":[
@@ -254,6 +281,9 @@
     "name:srp_x_preferred":[
         "\u0421\u0430\u043d \u0425\u0443\u0430\u043d"
     ],
+    "name:swa_x_preferred":[
+        "San Juan"
+    ],
     "name:swe_x_preferred":[
         "San Juan"
     ],
@@ -289,6 +319,9 @@
     ],
     "name:uzb_x_preferred":[
         "San Xuan"
+    ],
+    "name:vec_x_preferred":[
+        "San Juan"
     ],
     "name:vep_x_preferred":[
         "San Huan"
@@ -373,7 +406,7 @@
         }
     ],
     "wof:id":101919427,
-    "wof:lastmodified":1636502704,
+    "wof:lastmodified":1690855901,
     "wof:megacity":1,
     "wof:name":"San Juan",
     "wof:parent_id":102080441,

--- a/data/102/080/271/102080271.geojson
+++ b/data/102/080/271/102080271.geojson
@@ -46,11 +46,17 @@
     "name:eng_x_variant":[
         "Manat\u00ed Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0646\u0627\u062a\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Manat\u00ed"
     ],
     "name:fry_x_preferred":[
         "Manati"
+    ],
+    "name:gle_x_preferred":[
+        "Manat\u00ed"
     ],
     "name:hbs_x_preferred":[
         "Manat\u00ed"
@@ -66,6 +72,12 @@
     ],
     "name:pol_x_preferred":[
         "Manat\u00ed"
+    ],
+    "name:por_x_preferred":[
+        "Manat\u00ed"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u043d\u0430\u0442\u0438"
     ],
     "name:spa_x_preferred":[
         "Municipio Manat\u00ed"
@@ -136,7 +148,7 @@
         "wd:id":"Q674599"
     },
     "wof:country":"PR",
-    "wof:geomhash":"750e6c38f12e3344882a1f2331e7bd83",
+    "wof:geomhash":"ec5876b85864a0c57930139635fecfa0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +169,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855867,
     "wof:name":"Manat\u00ed",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/275/102080275.geojson
+++ b/data/102/080/275/102080275.geojson
@@ -28,6 +28,15 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ast_x_preferred":[
+        "Aguadilla"
+    ],
+    "name:azb_x_preferred":[
+        "\u0622\u0642\u0648\u0627\u062f\u06cc\u0644\u0627"
+    ],
+    "name:aze_x_preferred":[
+        "Aquadilya"
+    ],
     "name:bpy_x_preferred":[
         "\u0986\u0997\u09c1\u09f1\u09be\u09a1\u09bf\u09b2\u09be"
     ],
@@ -52,6 +61,9 @@
     "name:eng_x_variant":[
         "Aguadilla Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Aguadilla"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06af\u0648\u0627\u062f\u06cc\u0644\u0627"
     ],
@@ -69,6 +81,12 @@
     ],
     "name:kaz_x_preferred":[
         "\u0410\u0433\u0443\u0430\u0434\u0438\u043b\u044c\u044f"
+    ],
+    "name:kor_x_preferred":[
+        "\uc544\uacfc\ub514\uc57c"
+    ],
+    "name:lld_x_preferred":[
+        "Aguadilla"
     ],
     "name:nld_x_preferred":[
         "Aguadilla"
@@ -151,7 +169,7 @@
         "wd:id":"Q397826"
     },
     "wof:country":"PR",
-    "wof:geomhash":"02e1f2e89035103b5005541296469564",
+    "wof:geomhash":"eb791da3c36564481c0bff5e308236c9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -172,7 +190,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476301,
+    "wof:lastmodified":1690855858,
     "wof:name":"Aguadilla",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/279/102080279.geojson
+++ b/data/102/080/279/102080279.geojson
@@ -37,23 +37,38 @@
     "name:ceb_x_preferred":[
         "Coamo Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Coamo"
+    ],
     "name:eng_x_preferred":[
         "Coamo"
     ],
     "name:eng_x_variant":[
         "Coamo Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u0622\u0645\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Coamo"
+    ],
+    "name:gle_x_preferred":[
         "Coamo"
     ],
     "name:hbs_x_preferred":[
         "Coamo"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d5\u05d0\u05de\u05d5"
     ],
     "name:ita_x_preferred":[
         "Coamo"
     ],
     "name:jpn_x_preferred":[
         "\u30b3\u30a2\u30e2"
+    ],
+    "name:lld_x_preferred":[
+        "Coamo"
     ],
     "name:nld_x_preferred":[
         "Coamo"
@@ -87,6 +102,9 @@
     ],
     "name:war_x_preferred":[
         "Coamo"
+    ],
+    "name:wuu_x_preferred":[
+        "\u79d1\u963f\u83ab"
     ],
     "name:zho_x_preferred":[
         "\u79d1\u963f\u83ab"
@@ -133,7 +151,7 @@
         "wd:id":"Q1942303"
     },
     "wof:country":"PR",
-    "wof:geomhash":"f6b665625e8d0d1c75e5f75a99311c1d",
+    "wof:geomhash":"776ef71caa7df7191d0d004f5abfa15d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +172,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1690855866,
     "wof:name":"Coamo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/281/102080281.geojson
+++ b/data/102/080/281/102080281.geojson
@@ -37,13 +37,22 @@
     "name:ceb_x_preferred":[
         "Las Mar\u00edas"
     ],
+    "name:deu_x_preferred":[
+        "Las Mar\u00edas"
+    ],
     "name:eng_x_preferred":[
         "Las Mar\u00edas"
     ],
     "name:eng_x_variant":[
         "Las Mar\u00edas Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0627\u0633 \u0645\u0627\u0631\u06cc\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Las Mar\u00edas"
+    ],
+    "name:gle_x_preferred":[
         "Las Mar\u00edas"
     ],
     "name:hbs_x_preferred":[
@@ -60,6 +69,9 @@
     ],
     "name:por_x_preferred":[
         "Las Mar\u00edas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u0430\u0441-\u041c\u0430\u0440\u0438\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Municipio Las Mar\u00edas"
@@ -127,7 +139,7 @@
         "wd:id":"Q2485590"
     },
     "wof:country":"PR",
-    "wof:geomhash":"e6f5dde7c8dd39604c62849655446f18",
+    "wof:geomhash":"29a8e2da4a1e76b3cf71e5941c5eb8e6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +160,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855859,
     "wof:name":"Las Mar\u00edas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/283/102080283.geojson
+++ b/data/102/080/283/102080283.geojson
@@ -70,10 +70,19 @@
     "name:epo_x_preferred":[
         "Arecibo"
     ],
+    "name:eus_x_preferred":[
+        "Arecibo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0631\u0633\u06cc\u0628\u0648"
+    ],
     "name:fin_x_preferred":[
         "Arecibo"
     ],
     "name:fra_x_preferred":[
+        "Arecibo"
+    ],
+    "name:gle_x_preferred":[
         "Arecibo"
     ],
     "name:guj_x_preferred":[
@@ -112,6 +121,9 @@
     "name:lit_x_preferred":[
         "Aresibas"
     ],
+    "name:lld_x_preferred":[
+        "Arecibo"
+    ],
     "name:mar_x_preferred":[
         "\u0905\u0930\u093f\u0936\u093f\u0913"
     ],
@@ -136,6 +148,9 @@
     "name:por_x_preferred":[
         "Arecibo"
     ],
+    "name:ron_x_preferred":[
+        "Arecibo"
+    ],
     "name:rus_x_preferred":[
         "\u0410\u0440\u0435\u0441\u0438\u0431\u043e"
     ],
@@ -150,6 +165,9 @@
     ],
     "name:srp_x_preferred":[
         "\u0410\u0440\u0435\u0441\u0438\u0431\u043e"
+    ],
+    "name:swa_x_preferred":[
+        "Arecibo"
     ],
     "name:swe_x_preferred":[
         "Arecibo"
@@ -229,7 +247,7 @@
         "wd:id":"Q640728"
     },
     "wof:country":"PR",
-    "wof:geomhash":"35966e2838946100fbbeedd4e0442edd",
+    "wof:geomhash":"6b697acedc369f3c403871f51c70a084",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -250,7 +268,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1690855865,
     "wof:name":"Arecibo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/287/102080287.geojson
+++ b/data/102/080/287/102080287.geojson
@@ -49,11 +49,23 @@
     "name:eng_x_variant":[
         "Fajardo Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Fajardo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0641\u0627\u062c\u0627\u0631\u062f\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Fajardo"
+    ],
+    "name:gle_x_preferred":[
         "Fajardo"
     ],
     "name:heb_x_preferred":[
         "\u05e4\u05d0\u05d7\u05e8\u05d3\u05d5"
+    ],
+    "name:hye_x_preferred":[
+        "\u0556\u0561\u056d\u0561\u0580\u0564\u0578"
     ],
     "name:ita_x_preferred":[
         "Fajardo"
@@ -63,6 +75,9 @@
     ],
     "name:kaz_x_preferred":[
         "\u0424\u0430\u0445\u0430\u0440\u0434\u043e"
+    ],
+    "name:lld_x_preferred":[
+        "Fajardo"
     ],
     "name:nld_x_preferred":[
         "Fajardo"
@@ -143,7 +158,7 @@
         "wd:id":"Q542833"
     },
     "wof:country":"PR",
-    "wof:geomhash":"085a1c663e99a95e36fa141233b924a1",
+    "wof:geomhash":"deeaf11e630f9fdba6981f47d8160d2c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -164,7 +179,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1690855857,
     "wof:name":"Fajardo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/289/102080289.geojson
+++ b/data/102/080/289/102080289.geojson
@@ -37,13 +37,25 @@
     "name:ceb_x_preferred":[
         "Cata\u00f1o Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Cata\u00f1o"
+    ],
     "name:eng_x_preferred":[
         "Cata\u00f1o"
     ],
     "name:eng_x_variant":[
         "Cata\u00f1o Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Cata\u00f1o"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u062a\u0627\u0626\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Cata\u00f1o"
+    ],
+    "name:gle_x_preferred":[
         "Cata\u00f1o"
     ],
     "name:hbs_x_preferred":[
@@ -64,6 +76,9 @@
     "name:por_x_preferred":[
         "Cata\u00f1o"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u0442\u0430\u043d\u044c\u043e"
+    ],
     "name:sco_x_preferred":[
         "Cata\u00f1o"
     ],
@@ -75,6 +90,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0442\u0430\u045a\u043e"
+    ],
+    "name:swe_x_preferred":[
+        "Cata\u00f1o"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u0442\u0430\u043d\u044c\u0439\u043e"
@@ -133,7 +151,7 @@
         101918955
     ],
     "wof:country":"PR",
-    "wof:geomhash":"aa2df8e856dcc7acc617fd0ed1c27544",
+    "wof:geomhash":"034423e148ba9f107bcb14d70bd01eee",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +172,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1690855858,
     "wof:name":"Cata\u00f1o",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/291/102080291.geojson
+++ b/data/102/080/291/102080291.geojson
@@ -37,13 +37,22 @@
     "name:ceb_x_preferred":[
         "Comer\u00edo"
     ],
+    "name:deu_x_preferred":[
+        "Comer\u00edo"
+    ],
     "name:eng_x_preferred":[
         "Comer\u00edo"
     ],
     "name:eng_x_variant":[
         "Comer\u00edo Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0645\u0631\u06cc\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Comer\u00edo"
+    ],
+    "name:gle_x_preferred":[
         "Comer\u00edo"
     ],
     "name:hbs_x_preferred":[
@@ -60,6 +69,9 @@
     ],
     "name:por_x_preferred":[
         "Comer\u00edo"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u043c\u0435\u0440\u0438\u043e"
     ],
     "name:spa_x_preferred":[
         "Municipio Comer\u00edo"
@@ -124,7 +136,7 @@
         "wd:id":"Q2222328"
     },
     "wof:country":"PR",
-    "wof:geomhash":"91f581791e45b3bea1bc558625bb01fb",
+    "wof:geomhash":"200b8b150522f6efade15cbd20dd9113",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +157,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1690855868,
     "wof:name":"Comer\u00edo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/293/102080293.geojson
+++ b/data/102/080/293/102080293.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ara_x_preferred":[
+        "\u0643\u0627\u0645\u0648\u064a"
+    ],
     "name:bpy_x_preferred":[
         "\u0995\u09be\u09ae\u09c1\u09af\u09bc"
     ],
@@ -37,13 +40,25 @@
     "name:ceb_x_preferred":[
         "Camuy"
     ],
+    "name:deu_x_preferred":[
+        "Camuy"
+    ],
     "name:eng_x_preferred":[
         "Camuy"
     ],
     "name:eng_x_variant":[
         "Camuy Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Camuy"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0645\u0648\u06cc"
+    ],
     "name:fra_x_preferred":[
+        "Camuy"
+    ],
+    "name:gle_x_preferred":[
         "Camuy"
     ],
     "name:ita_x_preferred":[
@@ -52,11 +67,17 @@
     "name:jpn_x_preferred":[
         "\u30ab\u30e0\u30a4"
     ],
+    "name:lld_x_preferred":[
+        "Camuy"
+    ],
     "name:nld_x_preferred":[
         "Camuy"
     ],
     "name:por_x_preferred":[
         "Camuy"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u043c\u0443\u0439"
     ],
     "name:spa_x_preferred":[
         "Municipio Camuy"
@@ -121,7 +142,7 @@
         "wd:id":"Q2380860"
     },
     "wof:country":"PR",
-    "wof:geomhash":"ace1f199de0ab6900a8864a68e5211a9",
+    "wof:geomhash":"b476ff3f4b120f4add4f2b36628b5e38",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +163,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1690855860,
     "wof:name":"Camuy",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/297/102080297.geojson
+++ b/data/102/080/297/102080297.geojson
@@ -37,13 +37,25 @@
     "name:ceb_x_preferred":[
         "Guayanilla"
     ],
+    "name:deu_x_preferred":[
+        "Guayanilla"
+    ],
     "name:eng_x_preferred":[
         "Guayanilla"
     ],
     "name:eng_x_variant":[
         "Guayanilla Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Guayanilla"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0627\u06cc\u0627\u0646\u06cc\u0644\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Guayanilla"
+    ],
+    "name:gle_x_preferred":[
         "Guayanilla"
     ],
     "name:ita_x_preferred":[
@@ -52,11 +64,20 @@
     "name:jpn_x_preferred":[
         "\u30b0\u30a2\u30e4\u30cb\u30e9"
     ],
+    "name:lld_x_preferred":[
+        "Guayanilla"
+    ],
     "name:nld_x_preferred":[
+        "Guayanilla"
+    ],
+    "name:pol_x_preferred":[
         "Guayanilla"
     ],
     "name:por_x_preferred":[
         "Guayanilla"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0443\u0430\u044f\u043d\u0438\u043b\u044c\u044f"
     ],
     "name:spa_x_preferred":[
         "Municipio Guayanilla"
@@ -121,7 +142,7 @@
         "wd:id":"Q2333093"
     },
     "wof:country":"PR",
-    "wof:geomhash":"f9dabec7419cbf169af556d2c2ddc1a8",
+    "wof:geomhash":"b8007276e3573273aec11d4560b5c18f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +163,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1690855869,
     "wof:name":"Guayanilla",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/301/102080301.geojson
+++ b/data/102/080/301/102080301.geojson
@@ -34,13 +34,22 @@
     "name:cat_x_preferred":[
         "Juncos"
     ],
+    "name:deu_x_preferred":[
+        "Juncos"
+    ],
     "name:eng_x_preferred":[
         "Juncos"
     ],
     "name:eng_x_variant":[
         "Juncos Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u0648\u0646\u06a9\u0648\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Juncos"
+    ],
+    "name:gle_x_preferred":[
         "Juncos"
     ],
     "name:ita_x_preferred":[
@@ -48,6 +57,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d5\u30f3\u30b3\u30b9"
+    ],
+    "name:lld_x_preferred":[
+        "Juncos"
     ],
     "name:nld_x_preferred":[
         "Juncos"
@@ -57,6 +69,9 @@
     ],
     "name:por_x_preferred":[
         "Juncos"
+    ],
+    "name:rus_x_preferred":[
+        "\u0425\u0443\u043d\u043a\u043e\u0441"
     ],
     "name:spa_x_preferred":[
         "Municipio Juncos"
@@ -121,7 +136,7 @@
         "wd:id":"Q2347667"
     },
     "wof:country":"PR",
-    "wof:geomhash":"96ea1e163f4e276f9b28b20b0042aa99",
+    "wof:geomhash":"b10b5d30676c83b0483d238037c71820",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +157,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855855,
     "wof:name":"Juncos",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/305/102080305.geojson
+++ b/data/102/080/305/102080305.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u0648\u0642\u0627 \u0628\u0627\u062c\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u09ad\u09c7\u0997\u09be \u09ac\u09be\u099c\u09be"
     ],
@@ -35,6 +38,9 @@
         "Vega Baja"
     ],
     "name:ceb_x_preferred":[
+        "Vega Baja"
+    ],
+    "name:deu_x_preferred":[
         "Vega Baja"
     ],
     "name:eng_x_preferred":[
@@ -52,14 +58,23 @@
     "name:fra_x_preferred":[
         "Vega Baja"
     ],
+    "name:gle_x_preferred":[
+        "Vega Baja"
+    ],
     "name:hbs_x_preferred":[
         "Vega Baja"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d5\u05d5\u05d2\u05d4 \u05d1\u05d0\u05d7\u05d4"
     ],
     "name:ita_x_preferred":[
         "Vega Baja"
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30ac\u30fb\u30d0\u30cf"
+    ],
+    "name:lld_x_preferred":[
+        "Vega Baja"
     ],
     "name:nld_x_preferred":[
         "Vega Baja"
@@ -69,6 +84,9 @@
     ],
     "name:por_x_preferred":[
         "Vega Baja"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u0435\u0433\u0430-\u0411\u0430\u0445\u0430"
     ],
     "name:scn_x_preferred":[
         "Vega Baja"
@@ -142,7 +160,7 @@
         "wd:id":"Q2179051"
     },
     "wof:country":"PR",
-    "wof:geomhash":"50dcc88f5830dfe2ce61ac97cdf7f152",
+    "wof:geomhash":"f5d66261e57d813d19cfdfeae63c8d89",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -163,7 +181,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476308,
+    "wof:lastmodified":1690855864,
     "wof:name":"Vega Baja",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/311/102080311.geojson
+++ b/data/102/080/311/102080311.geojson
@@ -31,6 +31,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u064a\u0627\u062c\u0648\u064a\u0632"
     ],
+    "name:azb_x_preferred":[
+        "\u0645\u0627\u06cc\u0627\u0642\u0648\u0632"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09af\u09bc\u09be\u0997\u09cb\u09af\u09bc\u09c7\u099c"
     ],
@@ -64,6 +67,12 @@
     "name:eng_x_variant":[
         "Mayag\u00fcez Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Mayag\u00fcez"
+    ],
+    "name:eus_x_preferred":[
+        "Mayag\u00fcez"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u06af\u0648\u0626\u0632"
     ],
@@ -71,6 +80,9 @@
         "Mayag\u00fcez"
     ],
     "name:fra_x_preferred":[
+        "Mayag\u00fcez"
+    ],
+    "name:gle_x_preferred":[
         "Mayag\u00fcez"
     ],
     "name:glg_x_preferred":[
@@ -108,6 +120,9 @@
     ],
     "name:lit_x_preferred":[
         "Majaguesas"
+    ],
+    "name:lld_x_preferred":[
+        "Mayag\u00fcez"
     ],
     "name:mar_x_preferred":[
         "\u092e\u093e\u092f\u093e\u0917\u094d\u0935\u0947\u091d"
@@ -220,7 +235,7 @@
         "wd:id":"Q632727"
     },
     "wof:country":"PR",
-    "wof:geomhash":"85c2131be9422248d3cf645c930faf09",
+    "wof:geomhash":"2ca5b31d9b1744bc7f11e9d6868fd7ec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -241,7 +256,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855869,
     "wof:name":"Mayag\u00fcez",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/315/102080315.geojson
+++ b/data/102/080/315/102080315.geojson
@@ -31,6 +31,9 @@
     "name:ara_x_preferred":[
         "\u0641\u064a\u0643\u0648\u064a\u0633"
     ],
+    "name:azb_x_preferred":[
+        "\u0648\u06cc\u06a9\u0648\u0632"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0412'\u0435\u043a\u0435\u0441"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:ceb_x_preferred":[
         "Vieques Island"
+    ],
+    "name:ceb_x_variant":[
+        "Vieques Municipality"
     ],
     "name:ces_x_preferred":[
         "Vieques"
@@ -67,10 +73,16 @@
     "name:est_x_preferred":[
         "Vieques"
     ],
+    "name:fas_x_preferred":[
+        "\u0648\u06cc\u06a9"
+    ],
     "name:fin_x_preferred":[
         "Vieques"
     ],
     "name:fra_x_preferred":[
+        "Vieques"
+    ],
+    "name:gle_x_preferred":[
         "Vieques"
     ],
     "name:hbs_x_preferred":[
@@ -81,6 +93,9 @@
     ],
     "name:hye_x_preferred":[
         "\u053d\u0565\u0581\u0563\u0565\u057f\u0576\u056b \u056f\u0572\u0566\u056b"
+    ],
+    "name:ind_x_preferred":[
+        "Vieques"
     ],
     "name:ita_x_preferred":[
         "Vieques"
@@ -96,6 +111,9 @@
     ],
     "name:lit_x_preferred":[
         "Vjekesas"
+    ],
+    "name:lld_x_preferred":[
+        "Vieques"
     ],
     "name:nld_x_preferred":[
         "Vieques"
@@ -134,6 +152,12 @@
         "\u0412\u0438\u0458\u0435\u043a\u0435\u0441"
     ],
     "name:srp_x_variant":[
+        "Vieques"
+    ],
+    "name:swe_x_preferred":[
+        "Vieques"
+    ],
+    "name:tur_x_preferred":[
         "Vieques"
     ],
     "name:ukr_x_preferred":[
@@ -196,7 +220,7 @@
         "wd:id":"Q737624"
     },
     "wof:country":"PR",
-    "wof:geomhash":"fb2d82913f278e1fed6bde6518272f4a",
+    "wof:geomhash":"0d864a112f4be85b574567e17252daf3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -217,7 +241,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476308,
+    "wof:lastmodified":1690855861,
     "wof:name":"Vieques",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/317/102080317.geojson
+++ b/data/102/080/317/102080317.geojson
@@ -37,13 +37,22 @@
     "name:ceb_x_preferred":[
         "Ciales"
     ],
+    "name:deu_x_preferred":[
+        "Ciales"
+    ],
     "name:eng_x_preferred":[
         "Ciales"
     ],
     "name:eng_x_variant":[
         "Ciales Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u06cc\u0627\u0644\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Ciales"
+    ],
+    "name:gle_x_preferred":[
         "Ciales"
     ],
     "name:ita_x_preferred":[
@@ -51,6 +60,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b7\u30a2\u30ec\u30b9"
+    ],
+    "name:lld_x_preferred":[
+        "Ciales"
     ],
     "name:nld_x_preferred":[
         "Ciales"
@@ -124,7 +136,7 @@
         "wd:id":"Q2485522"
     },
     "wof:country":"PR",
-    "wof:geomhash":"39a034d12c4195525e56d41bde232029",
+    "wof:geomhash":"13ef0a4a99429f8bc5c9d6fbb99bf7d3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +157,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1690855871,
     "wof:name":"Ciales",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/319/102080319.geojson
+++ b/data/102/080/319/102080319.geojson
@@ -37,13 +37,22 @@
     "name:ceb_x_preferred":[
         "Pe\u00f1uelas Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
     "name:eng_x_preferred":[
         "Pe\u00f1uelas"
     ],
     "name:eng_x_variant":[
         "Pe\u00f1uelas Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0648\u0646\u0648\u0626\u0644\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
+    "name:gle_x_preferred":[
         "Pe\u00f1uelas"
     ],
     "name:glg_x_preferred":[
@@ -61,8 +70,14 @@
     "name:nld_x_preferred":[
         "Pe\u00f1uelas"
     ],
+    "name:pol_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
     "name:por_x_preferred":[
         "Pe\u00f1uelas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0435\u043d\u044c\u044e\u044d\u043b\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Municipio Pe\u00f1uelas"
@@ -130,7 +145,7 @@
         "wd:id":"Q369880"
     },
     "wof:country":"PR",
-    "wof:geomhash":"c768d7715d5ed8a3679bdfc84358bf10",
+    "wof:geomhash":"08d8aac53d657a553234898ffabaa01e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +166,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1690855871,
     "wof:name":"Pe\u00f1uelas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/321/102080321.geojson
+++ b/data/102/080/321/102080321.geojson
@@ -37,6 +37,12 @@
     "name:ceb_x_preferred":[
         "Aguas Buenas"
     ],
+    "name:deu_x_preferred":[
+        "Aguas Buenas"
+    ],
+    "name:ell_x_preferred":[
+        "\u0386\u03b3\u03bf\u03c5\u03b1\u03c2 \u0392\u03bf\u03c5\u03ad\u03bd\u03b1\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Aguas Buenas"
     ],
@@ -52,6 +58,9 @@
     "name:fra_x_preferred":[
         "Aguas Buenas"
     ],
+    "name:gle_x_preferred":[
+        "Aguas Buenas"
+    ],
     "name:hye_x_preferred":[
         "\u0531\u0563\u0578\u0582\u0561\u057d \u0532\u0578\u0582\u0565\u0576\u0561\u057d"
     ],
@@ -61,11 +70,17 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30b0\u30a2\u30b9\u30fb\u30d6\u30a8\u30ca\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Aguas Buenas"
+    ],
     "name:nld_x_preferred":[
         "Aguas Buenas"
     ],
     "name:por_x_preferred":[
         "Aguas Buenas"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0433\u0443\u0430\u0441-\u0411\u0443\u044d\u043d\u0430\u0441"
     ],
     "name:scn_x_preferred":[
         "Aguas Buenas"
@@ -133,7 +148,7 @@
         "wd:id":"Q2361568"
     },
     "wof:country":"PR",
-    "wof:geomhash":"d65a334c1a9c7d7f68e573e27880cd05",
+    "wof:geomhash":"9050a455ace35689882bb71d85286c94",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +169,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476301,
+    "wof:lastmodified":1690855871,
     "wof:name":"Aguas Buenas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/323/102080323.geojson
+++ b/data/102/080/323/102080323.geojson
@@ -37,13 +37,25 @@
     "name:ceb_x_preferred":[
         "A\u00f1asco"
     ],
+    "name:deu_x_preferred":[
+        "A\u00f1asco"
+    ],
     "name:eng_x_preferred":[
         "A\u00f1asco"
     ],
     "name:eng_x_variant":[
         "A\u00f1asco Municipality"
     ],
+    "name:epo_x_preferred":[
+        "A\u00f1asco"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0648\u0646\u0633\u06a9\u0648"
+    ],
     "name:fra_x_preferred":[
+        "A\u00f1asco"
+    ],
+    "name:gle_x_preferred":[
         "A\u00f1asco"
     ],
     "name:hbs_x_preferred":[
@@ -58,8 +70,14 @@
     "name:nld_x_preferred":[
         "A\u00f1asco"
     ],
+    "name:pol_x_preferred":[
+        "A\u00f1asco"
+    ],
     "name:por_x_preferred":[
         "A\u00f1asco"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u043d\u044c\u044f\u0441\u043a\u043e"
     ],
     "name:spa_x_preferred":[
         "Municipio A\u00f1asco"
@@ -124,7 +142,7 @@
         "wd:id":"Q2390910"
     },
     "wof:country":"PR",
-    "wof:geomhash":"aeaf241b8cc3d42b9a81227a16849d58",
+    "wof:geomhash":"4830d4d593c28fea070bbeaac49cb235",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +163,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1690855861,
     "wof:name":"A\u00f1asco",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/325/102080325.geojson
+++ b/data/102/080/325/102080325.geojson
@@ -31,10 +31,19 @@
     "name:azb_x_preferred":[
         "\u06a9\u0648\u0626\u0628\u0631\u0627\u062f\u06cc\u0644\u0627\u0633"
     ],
+    "name:bpy_x_preferred":[
+        "\u0995\u09c1\u09af\u09bc\u09c7\u09ac\u09cd\u09b0\u09be\u09a1\u09bf\u09b2\u09cd\u09b2\u09be\u09b8"
+    ],
     "name:cat_x_preferred":[
         "Quebradillas"
     ],
     "name:ceb_x_preferred":[
+        "Quebradillas"
+    ],
+    "name:ceb_x_variant":[
+        "Quebradillas Municipio"
+    ],
+    "name:deu_x_preferred":[
         "Quebradillas"
     ],
     "name:eng_x_preferred":[
@@ -43,10 +52,16 @@
     "name:eng_x_variant":[
         "Quebradillas Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Quebradillas"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0626\u0628\u0631\u0627\u062f\u06cc\u0644\u0627\u0633"
     ],
     "name:fra_x_preferred":[
+        "Quebradillas"
+    ],
+    "name:gle_x_preferred":[
         "Quebradillas"
     ],
     "name:ita_x_preferred":[
@@ -55,11 +70,20 @@
     "name:jpn_x_preferred":[
         "\u30b1\u30d6\u30e9\u30c7\u30a3\u30fc\u30b8\u30e3\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Quebradillas"
+    ],
     "name:nld_x_preferred":[
+        "Quebradillas"
+    ],
+    "name:pol_x_preferred":[
         "Quebradillas"
     ],
     "name:por_x_preferred":[
         "Quebradillas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u0435\u0431\u0440\u0430\u0434\u0438\u043b\u044c\u044f\u0441"
     ],
     "name:spa_x_preferred":[
         "Municipio Quebradillas"
@@ -124,7 +148,7 @@
         "wd:id":"Q2057872"
     },
     "wof:country":"PR",
-    "wof:geomhash":"0da89cd99fdd608551b0600342747236",
+    "wof:geomhash":"d51fac8c56f44af8ce13acc73c89c45a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +169,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1690855862,
     "wof:name":"Quebradillas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/329/102080329.geojson
+++ b/data/102/080/329/102080329.geojson
@@ -28,6 +28,15 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ara_x_preferred":[
+        "\u062a\u0648\u0627\u0628\u0627\u062e\u0627"
+    ],
+    "name:azb_x_preferred":[
+        "\u062a\u0648\u0627 \u0628\u0627\u062c\u0627"
+    ],
+    "name:bpy_x_preferred":[
+        "\u099f\u09f1\u09be \u09ac\u09be\u099c\u09be"
+    ],
     "name:cat_x_preferred":[
         "Toa Baja"
     ],
@@ -46,7 +55,13 @@
     "name:eng_x_variant":[
         "Toa Baja Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0648\u0622 \u0628\u0627\u062e\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Toa Baja"
+    ],
+    "name:gle_x_preferred":[
         "Toa Baja"
     ],
     "name:ita_x_preferred":[
@@ -55,11 +70,20 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30a2\u30fb\u30d0\u30cf"
     ],
+    "name:lld_x_preferred":[
+        "Toa Baja"
+    ],
     "name:nld_x_preferred":[
+        "Toa Baja"
+    ],
+    "name:pol_x_preferred":[
         "Toa Baja"
     ],
     "name:por_x_preferred":[
         "Toa Baixa"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u043e\u0430-\u0411\u0430\u0445\u0430"
     ],
     "name:scn_x_preferred":[
         "Toa Baja"
@@ -72,6 +96,9 @@
     ],
     "name:srp_x_preferred":[
         "\u0422\u043e\u0430 \u0411\u0430\u0445\u0430"
+    ],
+    "name:swe_x_preferred":[
+        "Toa Baja"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u043e\u0430-\u0411\u0430\u0445\u0430"
@@ -127,7 +154,7 @@
         "wd:id":"Q2238070"
     },
     "wof:country":"PR",
-    "wof:geomhash":"08ebb3c8899bb80a156e4e47f0765b23",
+    "wof:geomhash":"4f77659511f28f88bba8252b602a8ba7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +175,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1690855869,
     "wof:name":"Toa Baja",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/333/102080333.geojson
+++ b/data/102/080/333/102080333.geojson
@@ -37,13 +37,25 @@
     "name:ceb_x_preferred":[
         "Barranquitas"
     ],
+    "name:deu_x_preferred":[
+        "Barranquitas"
+    ],
     "name:eng_x_preferred":[
         "Barranquitas"
     ],
     "name:eng_x_variant":[
         "Barranquitas Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Barranquitas"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u0631\u0631\u0627\u0646\u06a9\u06cc\u062a\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Barranquitas"
+    ],
+    "name:gle_x_preferred":[
         "Barranquitas"
     ],
     "name:ita_x_preferred":[
@@ -52,11 +64,17 @@
     "name:jpn_x_preferred":[
         "\u30d0\u30e9\u30f3\u30ad\u30bf\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Barranquitas"
+    ],
     "name:nld_x_preferred":[
         "Barranquitas"
     ],
     "name:por_x_preferred":[
         "Barranquitas"
+    ],
+    "name:rus_x_preferred":[
+        "\u0411\u0430\u0440\u0440\u0430\u043d\u043a\u0438\u0442\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Municipio Barranquitas"
@@ -121,7 +139,7 @@
         "wd:id":"Q2485615"
     },
     "wof:country":"PR",
-    "wof:geomhash":"e4860ebfd96e49590e132f70776d45a2",
+    "wof:geomhash":"eac31a0d222c3a81c6d25d8f969d0132",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +160,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1690855864,
     "wof:name":"Barranquitas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/339/102080339.geojson
+++ b/data/102/080/339/102080339.geojson
@@ -46,7 +46,13 @@
     "name:eng_x_variant":[
         "Luquillo Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0648\u06a9\u06cc\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Luquillo"
+    ],
+    "name:gle_x_preferred":[
         "Luquillo"
     ],
     "name:ita_x_preferred":[
@@ -54,6 +60,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30eb\u30ad\u30ea\u30e7"
+    ],
+    "name:lld_x_preferred":[
+        "Luquillo"
     ],
     "name:nld_x_preferred":[
         "Luquillo"
@@ -133,7 +142,7 @@
         "wd:id":"Q1984618"
     },
     "wof:country":"PR",
-    "wof:geomhash":"4aed70fdde163eeee1c1ca066a71687a",
+    "wof:geomhash":"fb069723f3bfb9bf8b963560b4e2842f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +163,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855856,
     "wof:name":"Luquillo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/341/102080341.geojson
+++ b/data/102/080/341/102080341.geojson
@@ -31,6 +31,12 @@
     "name:ara_x_preferred":[
         "\u0642\u0627\u0628\u0648\u0642"
     ],
+    "name:arg_x_preferred":[
+        "Ceiba"
+    ],
+    "name:arz_x_preferred":[
+        "\u0642\u0627\u0628\u0648\u0642"
+    ],
     "name:ast_x_preferred":[
         "Ceiba"
     ],
@@ -42,6 +48,9 @@
     ],
     "name:bul_x_preferred":[
         "Ceiba"
+    ],
+    "name:bul_x_variant":[
+        "\u0441\u0435\u0439\u0431\u0430"
     ],
     "name:cat_x_preferred":[
         "Ceiba"
@@ -64,20 +73,59 @@
     "name:eng_x_variant":[
         "Ceiba Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Ceiba"
+    ],
+    "name:eus_x_preferred":[
+        "Ceiba"
+    ],
+    "name:ext_x_preferred":[
+        "Ceiba"
+    ],
+    "name:fas_x_preferred":[
+        "\u0633\u06cc\u0628\u0627"
+    ],
     "name:fin_x_preferred":[
         "Kapokkipuut"
     ],
     "name:fra_x_preferred":[
         "Ceiba"
     ],
+    "name:gle_x_preferred":[
+        "Ceiba"
+    ],
+    "name:glg_x_preferred":[
+        "Ceiba"
+    ],
     "name:heb_x_preferred":[
         "\u05db\u05d5\u05e8\u05d9\u05d6\u05d9\u05d4"
+    ],
+    "name:hye_x_preferred":[
+        "\u054d\u0565\u0575\u0562\u0561"
+    ],
+    "name:ido_x_preferred":[
+        "Ceiba"
+    ],
+    "name:ile_x_preferred":[
+        "Ceiba"
+    ],
+    "name:ina_x_preferred":[
+        "Ceiba"
+    ],
+    "name:ind_x_preferred":[
+        "Ceiba"
     ],
     "name:ita_x_preferred":[
         "Ceiba"
     ],
+    "name:jpn_x_preferred":[
+        "\u30bb\u30a4\u30d0\u5c5e"
+    ],
     "name:kor_x_preferred":[
         "\uc591\ubaa9\uba74\uc18d"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc774\ubc14"
     ],
     "name:lat_x_preferred":[
         "Ceiba"
@@ -86,6 +134,15 @@
         "Kapokmedis"
     ],
     "name:nld_x_preferred":[
+        "Ceiba"
+    ],
+    "name:nno_x_preferred":[
+        "Ceiba"
+    ],
+    "name:nob_x_preferred":[
+        "Ceiba"
+    ],
+    "name:oci_x_preferred":[
         "Ceiba"
     ],
     "name:pnb_x_preferred":[
@@ -97,6 +154,9 @@
     "name:por_x_preferred":[
         "Ceiba"
     ],
+    "name:ron_x_preferred":[
+        "Ceiba"
+    ],
     "name:rus_x_preferred":[
         "\u0421\u0435\u0439\u0431\u0430"
     ],
@@ -104,6 +164,9 @@
         "Municipio Ceiba"
     ],
     "name:spa_x_variant":[
+        "Ceiba"
+    ],
+    "name:sqi_x_preferred":[
         "Ceiba"
     ],
     "name:swe_x_preferred":[
@@ -115,11 +178,17 @@
     "name:vie_x_preferred":[
         "Chi B\u00f4ng g\u00f2n"
     ],
+    "name:vol_x_preferred":[
+        "Ceiba"
+    ],
     "name:war_x_preferred":[
         "Ceiba"
     ],
     "name:zho_x_preferred":[
         "\u722a\u54c7\u6728\u68c9\u5c5e"
+    ],
+    "name:zho_x_variant":[
+        "\u5409\u8d1d\u5c5e"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1_lc":"72",
@@ -164,7 +233,7 @@
         "wd:id":"Q284019"
     },
     "wof:country":"PR",
-    "wof:geomhash":"755acb98bb50a2f645c66535b10acc4a",
+    "wof:geomhash":"416fe1573abd700949f7319eed2dfeab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -185,7 +254,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1690855861,
     "wof:name":"Ceiba",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/351/102080351.geojson
+++ b/data/102/080/351/102080351.geojson
@@ -40,13 +40,22 @@
     "name:dan_x_preferred":[
         "Humacao"
     ],
+    "name:deu_x_preferred":[
+        "Humacao"
+    ],
     "name:eng_x_preferred":[
         "Humacao"
     ],
     "name:eng_x_variant":[
         "Humacao Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0647\u0648\u0645\u0627\u06a9\u0627\u0626\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Humacao"
+    ],
+    "name:gle_x_preferred":[
         "Humacao"
     ],
     "name:heb_x_preferred":[
@@ -58,6 +67,9 @@
     "name:jpn_x_preferred":[
         "\u30a6\u30de\u30ab\u30aa"
     ],
+    "name:lld_x_preferred":[
+        "Humacao"
+    ],
     "name:nld_x_preferred":[
         "Humacao"
     ],
@@ -65,6 +77,9 @@
         "Humacao"
     ],
     "name:por_x_preferred":[
+        "Humacao"
+    ],
+    "name:ron_x_preferred":[
         "Humacao"
     ],
     "name:rus_x_preferred":[
@@ -77,6 +92,9 @@
         "Humacao"
     ],
     "name:srp_x_preferred":[
+        "Humacao"
+    ],
+    "name:szl_x_preferred":[
         "Humacao"
     ],
     "name:ukr_x_preferred":[
@@ -133,7 +151,7 @@
         "wd:id":"Q2307535"
     },
     "wof:country":"PR",
-    "wof:geomhash":"6e47d4dd9abe855f7bc62e522093f34b",
+    "wof:geomhash":"8333bcde0e84b6bb63fa842129be9d9d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +172,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1690855863,
     "wof:name":"Humacao",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/355/102080355.geojson
+++ b/data/102/080/355/102080355.geojson
@@ -28,10 +28,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:bpy_x_preferred":[
+        "\u09a8\u09be\u0997\u09c1\u09f1\u09be\u09ac\u09cb"
+    ],
     "name:cat_x_preferred":[
         "Naguabo"
     ],
     "name:ceb_x_preferred":[
+        "Naguabo"
+    ],
+    "name:deu_x_preferred":[
         "Naguabo"
     ],
     "name:eng_x_preferred":[
@@ -40,7 +46,13 @@
     "name:eng_x_variant":[
         "Naguabo Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u06af\u0648\u0627\u0628\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Naguabo"
+    ],
+    "name:gle_x_preferred":[
         "Naguabo"
     ],
     "name:ita_x_preferred":[
@@ -49,8 +61,17 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30b0\u30a2\u30dc"
     ],
+    "name:lld_x_preferred":[
+        "Naguabo"
+    ],
     "name:nld_x_preferred":[
         "Nag\u00fcabo"
+    ],
+    "name:pol_x_preferred":[
+        "Naguabo"
+    ],
+    "name:por_x_preferred":[
+        "Naguabo"
     ],
     "name:rus_x_preferred":[
         "\u041d\u0430\u0433\u0443\u0430\u0431\u043e"
@@ -63,6 +84,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041d\u0430\u0433\u0432\u0430\u0431\u043e"
+    ],
+    "name:swe_x_preferred":[
+        "Naguabo"
     ],
     "name:ukr_x_preferred":[
         "\u041d\u0430\u0433\u0443\u0430\u0431\u043e"
@@ -118,7 +142,7 @@
         "wd:id":"Q2659720"
     },
     "wof:country":"PR",
-    "wof:geomhash":"f64abbc20ac6bbec15d0987ef21194c0",
+    "wof:geomhash":"22c4eb37fe1b1676e69b11cb140949b3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +163,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1690855856,
     "wof:name":"Naguabo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/357/102080357.geojson
+++ b/data/102/080/357/102080357.geojson
@@ -28,8 +28,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ara_x_preferred":[
+        "\u0633\u0627\u0646 \u062e\u064a\u0631\u0645\u0627\u0646"
+    ],
+    "name:bpy_x_preferred":[
+        "\u09b8\u09be\u09a8 \u099c\u09be\u09b0\u09cd\u09ae\u09be\u09a8"
+    ],
     "name:cat_x_preferred":[
         "San Germ\u00e1n"
+    ],
+    "name:ceb_x_preferred":[
+        "San Germ\u00e1n Municipio"
     ],
     "name:cym_x_preferred":[
         "San Germ\u00e1n"
@@ -46,17 +55,29 @@
     "name:epo_x_preferred":[
         "San Germ\u00e1n"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0646 \u0698\u0631\u0645\u0646"
+    ],
     "name:fra_x_preferred":[
+        "San Germ\u00e1n"
+    ],
+    "name:gle_x_preferred":[
         "San Germ\u00e1n"
     ],
     "name:hbs_x_preferred":[
         "San Germ\u00e1n"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d0\u05df \u05d7\u05e8\u05de\u05d9\u05d0\u05df"
     ],
     "name:ita_x_preferred":[
         "San Germ\u00e1n"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30d8\u30eb\u30de\u30f3"
+    ],
+    "name:lld_x_preferred":[
+        "San Germ\u00e1n"
     ],
     "name:nld_x_preferred":[
         "San Germ\u00e1n"
@@ -139,7 +160,7 @@
         "wd:id":"Q1598808"
     },
     "wof:country":"PR",
-    "wof:geomhash":"1e33a08d5d34937a0e7ce7275cd99ad5",
+    "wof:geomhash":"db794ebe45931c70132f8c9b21a217d7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -160,7 +181,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1690855863,
     "wof:name":"San Germ\u00e1n",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/359/102080359.geojson
+++ b/data/102/080/359/102080359.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u062a\u0648\u0627 \u0622\u0644\u062a\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u099f\u09f1\u09be \u0986\u09b2\u099f\u09be"
     ],
@@ -37,13 +40,22 @@
     "name:ceb_x_preferred":[
         "Toa Alta"
     ],
+    "name:deu_x_preferred":[
+        "Toa Alta"
+    ],
     "name:eng_x_preferred":[
         "Toa Alta"
     ],
     "name:eng_x_variant":[
         "Toa Alta Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0648\u0622 \u0622\u0644\u062a\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Toa Alta"
+    ],
+    "name:gle_x_preferred":[
         "Toa Alta"
     ],
     "name:ita_x_preferred":[
@@ -52,11 +64,17 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30a2\u30fb\u30a2\u30eb\u30bf"
     ],
+    "name:lld_x_preferred":[
+        "Toa Alta"
+    ],
     "name:nld_x_preferred":[
         "Toa Alta"
     ],
     "name:por_x_preferred":[
         "Toa Alta"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u043e\u0430-\u0410\u043b\u044c\u0442\u0430"
     ],
     "name:scn_x_preferred":[
         "Toa Alta"
@@ -124,7 +142,7 @@
         "wd:id":"Q2485509"
     },
     "wof:country":"PR",
-    "wof:geomhash":"2308785765840e19e49cc10b561584ce",
+    "wof:geomhash":"0d854ef9e88838d1b9e26733f953aadb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +163,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1690855863,
     "wof:name":"Toa Alta",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/361/102080361.geojson
+++ b/data/102/080/361/102080361.geojson
@@ -28,10 +28,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:bpy_x_preferred":[
+        "\u099f\u09cd\u09b0\u09c1\u099c\u09bf\u09b2\u09cd\u09b2\u09cb \u0986\u09b2\u099f\u09cb"
+    ],
     "name:cat_x_preferred":[
         "Trujillo Alto"
     ],
     "name:ceb_x_preferred":[
+        "Trujillo Alto"
+    ],
+    "name:deu_x_preferred":[
         "Trujillo Alto"
     ],
     "name:eng_x_preferred":[
@@ -49,6 +55,9 @@
     "name:fra_x_preferred":[
         "Trujillo Alto"
     ],
+    "name:gle_x_preferred":[
+        "Trujillo Alto"
+    ],
     "name:ita_x_preferred":[
         "Trujillo Alto"
     ],
@@ -57,6 +66,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud2b8\ub8e8\ud788\uc694\uc54c\ud1a0"
+    ],
+    "name:lld_x_preferred":[
+        "Trujillo Alto"
     ],
     "name:nld_x_preferred":[
         "Trujillo Alto"
@@ -81,6 +93,9 @@
     ],
     "name:srp_x_preferred":[
         "\u0422\u0440\u0443\u0445\u0438\u0459\u043e \u0410\u043b\u0442\u043e"
+    ],
+    "name:szl_x_preferred":[
+        "Trujillo Alto"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0440\u0443\u0445\u0456\u043b\u044c\u0439\u043e-\u0410\u043b\u044c\u0442\u043e"
@@ -136,7 +151,7 @@
         "wd:id":"Q1150895"
     },
     "wof:country":"PR",
-    "wof:geomhash":"1e239a76c7137bcaf32f8bb03de3e7dc",
+    "wof:geomhash":"4533eeb028a6f09f0b8372fabd6b3eb7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +172,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1690855862,
     "wof:name":"Trujillo Alto",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/363/102080363.geojson
+++ b/data/102/080/363/102080363.geojson
@@ -40,13 +40,22 @@
     "name:deu_x_preferred":[
         "Lo\u00edza"
     ],
+    "name:ell_x_preferred":[
+        "\u039b\u03bf\u0390\u03c3\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Lo\u00edza"
     ],
     "name:eng_x_variant":[
         "Lo\u00edza Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0648\u06cc\u0632\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Lo\u00edza"
+    ],
+    "name:gle_x_preferred":[
         "Lo\u00edza"
     ],
     "name:hbs_x_preferred":[
@@ -58,6 +67,9 @@
     "name:jpn_x_preferred":[
         "\u30ed\u30a4\u30b5"
     ],
+    "name:lld_x_preferred":[
+        "Lo\u00edza"
+    ],
     "name:nld_x_preferred":[
         "Lo\u00edza"
     ],
@@ -66,6 +78,9 @@
     ],
     "name:por_x_preferred":[
         "Lo\u00edza"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u043e\u0438\u0441\u0430"
     ],
     "name:spa_x_preferred":[
         "Municipio Lo\u00edza"
@@ -133,7 +148,7 @@
         "wd:id":"Q1853983"
     },
     "wof:country":"PR",
-    "wof:geomhash":"60e45cea3ad36c178ec30b743d63994a",
+    "wof:geomhash":"502b4cca79f55992e6855f8fec2039d4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +169,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855856,
     "wof:name":"Lo\u00edza",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/365/102080365.geojson
+++ b/data/102/080/365/102080365.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u0642\u0648\u0627\u06cc\u0646\u0627\u0628\u0648"
+    ],
     "name:bpy_x_preferred":[
         "\u0997\u09c1\u09f1\u09be\u09af\u09bc\u09a8\u09be\u09ac\u09cb"
     ],
@@ -55,6 +58,9 @@
     "name:fra_x_preferred":[
         "Guaynabo"
     ],
+    "name:gle_x_preferred":[
+        "Guaynabo"
+    ],
     "name:ita_x_preferred":[
         "Guaynabo"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:lit_x_preferred":[
         "Guainabas"
+    ],
+    "name:lld_x_preferred":[
+        "Guaynabo"
     ],
     "name:mkd_x_preferred":[
         "\u0413\u0443\u0430\u0458\u043d\u0430\u0431\u043e"
@@ -76,6 +85,9 @@
     "name:por_x_preferred":[
         "Guaynabo"
     ],
+    "name:rus_x_preferred":[
+        "\u0413\u0443\u0430\u0439\u043d\u0430\u0431\u043e"
+    ],
     "name:sco_x_preferred":[
         "Guaynabo"
     ],
@@ -86,6 +98,12 @@
         "Guaynabo"
     ],
     "name:srp_x_preferred":[
+        "Guaynabo"
+    ],
+    "name:swa_x_preferred":[
+        "Guaynabo"
+    ],
+    "name:swe_x_preferred":[
         "Guaynabo"
     ],
     "name:ukr_x_preferred":[
@@ -142,7 +160,7 @@
         "wd:id":"Q590060"
     },
     "wof:country":"PR",
-    "wof:geomhash":"762d42801053709e09bd5214687c3fa2",
+    "wof:geomhash":"5500733b08ed2daf30c8bd47043e1b2b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -163,7 +181,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1690855855,
     "wof:name":"Guaynabo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/371/102080371.geojson
+++ b/data/102/080/371/102080371.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u06cc\u0627\u0628\u0648\u06a9\u0648\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u09af\u09bc\u09be\u09ac\u09c1\u0995\u09cb\u09af\u09bc\u09be"
     ],
@@ -37,16 +40,28 @@
     "name:ceb_x_preferred":[
         "Yabucoa"
     ],
+    "name:deu_x_preferred":[
+        "Yabucoa"
+    ],
     "name:eng_x_preferred":[
         "Yabucoa"
     ],
     "name:eng_x_variant":[
         "Yabucoa Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Yabucoa"
+    ],
     "name:est_x_preferred":[
         "Yabucoa"
     ],
+    "name:fas_x_preferred":[
+        "\u06cc\u0627\u0628\u0648\u0633\u0627\u0622"
+    ],
     "name:fra_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:gle_x_preferred":[
         "Yabucoa"
     ],
     "name:ita_x_preferred":[
@@ -55,8 +70,20 @@
     "name:jpn_x_preferred":[
         "\u30e4\u30d6\u30b3\u30a2"
     ],
+    "name:lld_x_preferred":[
+        "Yabucoa"
+    ],
     "name:nld_x_preferred":[
         "Yabucoa"
+    ],
+    "name:pol_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:por_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:rus_x_preferred":[
+        "\u042f\u0431\u0443\u043a\u043e\u0430"
     ],
     "name:scn_x_preferred":[
         "Yabucoa"
@@ -127,7 +154,7 @@
         "wd:id":"Q2361097"
     },
     "wof:country":"PR",
-    "wof:geomhash":"166b37661bb9a0df9f69dcaf1d0ec70f",
+    "wof:geomhash":"e1ed923c202eb27fe0cde54dc835a3f3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +175,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476308,
+    "wof:lastmodified":1690855862,
     "wof:name":"Yabucoa",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/373/102080373.geojson
+++ b/data/102/080/373/102080373.geojson
@@ -52,7 +52,16 @@
     "name:eng_x_variant":[
         "Guayama Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Guayama"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0627\u06cc\u0627\u0645\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Guayama"
+    ],
+    "name:gle_x_preferred":[
         "Guayama"
     ],
     "name:hye_x_preferred":[
@@ -63,6 +72,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b0\u30a2\u30e4\u30de"
+    ],
+    "name:lld_x_preferred":[
+        "Guayama"
     ],
     "name:nld_x_preferred":[
         "Guayama"
@@ -142,7 +154,7 @@
         "wd:id":"Q1870997"
     },
     "wof:country":"PR",
-    "wof:geomhash":"ef0a2502134758663cd7f3b686e2e372",
+    "wof:geomhash":"b7ac90e900bdc52ff0e5e73d2a1ad94e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -163,7 +175,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1690855870,
     "wof:name":"Guayama",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/379/102080379.geojson
+++ b/data/102/080/379/102080379.geojson
@@ -82,6 +82,9 @@
     "name:heb_x_preferred":[
         "\u05dc\u05d0\u05e8\u05e1"
     ],
+    "name:hun_x_preferred":[
+        "larok"
+    ],
     "name:ind_x_preferred":[
         "Lares"
     ],
@@ -96,6 +99,9 @@
     ],
     "name:lat_x_preferred":[
         "Lar"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041b\u0430\u0440\u0438"
     ],
     "name:nld_x_preferred":[
         "Laren"
@@ -123,6 +129,9 @@
     ],
     "name:spa_x_variant":[
         "Lares"
+    ],
+    "name:srp_x_preferred":[
+        "\u041b\u0430\u0440\u0438"
     ],
     "name:swe_x_preferred":[
         "Larer"
@@ -181,7 +190,7 @@
         "wd:id":"Q504377"
     },
     "wof:country":"PR",
-    "wof:geomhash":"5c8d4f08648a970c8f3976e89d6205b2",
+    "wof:geomhash":"4146cdc41f7e710c7c2b42e452fe76d4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -202,7 +211,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855861,
     "wof:name":"Lares",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/387/102080387.geojson
+++ b/data/102/080/387/102080387.geojson
@@ -37,13 +37,25 @@
     "name:ceb_x_preferred":[
         "Canovanas"
     ],
+    "name:deu_x_preferred":[
+        "Can\u00f3vanas"
+    ],
     "name:eng_x_preferred":[
         "Can\u00f3vanas"
     ],
     "name:eng_x_variant":[
         "Can\u00f3vanas Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Can\u00f3vanas"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0646\u0648\u0648\u0627\u0646\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Can\u00f3vanas"
+    ],
+    "name:gle_x_preferred":[
         "Can\u00f3vanas"
     ],
     "name:hbs_x_preferred":[
@@ -75,6 +87,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u043d\u043e\u0432\u0430\u043d\u0430\u0441"
+    ],
+    "name:swe_x_preferred":[
+        "Can\u00f3vanas"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u043d\u043e\u0432\u0430\u043d\u0430\u0441"
@@ -130,7 +145,7 @@
         "wd:id":"Q2361552"
     },
     "wof:country":"PR",
-    "wof:geomhash":"8e3a2c9fa91ea5debeaf342b6ec65b9c",
+    "wof:geomhash":"c59665499a81d2dc8d7b84f9f952d959",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +166,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1690855870,
     "wof:name":"Can\u00f3vanas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/389/102080389.geojson
+++ b/data/102/080/389/102080389.geojson
@@ -37,13 +37,22 @@
     "name:ceb_x_preferred":[
         "Maunabo"
     ],
+    "name:deu_x_preferred":[
+        "Maunabo"
+    ],
     "name:eng_x_preferred":[
         "Maunabo"
     ],
     "name:eng_x_variant":[
         "Maunabo Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0648\u0646\u0627\u0628\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Maunabo"
+    ],
+    "name:gle_x_preferred":[
         "Maunabo"
     ],
     "name:ita_x_preferred":[
@@ -52,8 +61,17 @@
     "name:jpn_x_preferred":[
         "\u30de\u30a6\u30ca\u30dc"
     ],
+    "name:lld_x_preferred":[
+        "Maunabo"
+    ],
     "name:nld_x_preferred":[
         "Maunabo"
+    ],
+    "name:por_x_preferred":[
+        "Maunabo"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u0443\u043d\u0430\u0431\u043e"
     ],
     "name:spa_x_preferred":[
         "Municipio Maunabo"
@@ -118,7 +136,7 @@
         "wd:id":"Q967149"
     },
     "wof:country":"PR",
-    "wof:geomhash":"76faa7a56c1a08b160ae340b2c813219",
+    "wof:geomhash":"aac0a6552541f0315f2a3785ba25daed",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +157,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855870,
     "wof:name":"Maunabo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/393/102080393.geojson
+++ b/data/102/080/393/102080393.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u0622\u062f\u062c\u0648\u0646\u062a\u0627\u0633"
+    ],
     "name:bpy_x_preferred":[
         "\u0985\u09cd\u09af\u09be\u09a1\u099c\u09c1\u09a8\u099f\u09be\u09b8"
     ],
@@ -37,11 +40,17 @@
     "name:ceb_x_preferred":[
         "Adjuntas"
     ],
+    "name:deu_x_preferred":[
+        "Adjuntas"
+    ],
     "name:eng_x_preferred":[
         "Adjuntas"
     ],
     "name:eng_x_variant":[
         "Adjuntas Municipality"
+    ],
+    "name:epo_x_preferred":[
+        "Adjuntas"
     ],
     "name:fas_x_preferred":[
         "\u0627\u062c\u0648\u0646\u062a\u0627\u0633\u060c \u067e\u0648\u0631\u062a\u0648\u0631\u06cc\u06a9\u0648"
@@ -50,6 +59,9 @@
         "\u0627\u062c\u0648\u0646\u062a\u0627\u0633"
     ],
     "name:fra_x_preferred":[
+        "Adjuntas"
+    ],
+    "name:gle_x_preferred":[
         "Adjuntas"
     ],
     "name:hbs_x_preferred":[
@@ -61,11 +73,20 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30c9\u30d5\u30f3\u30bf\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Adjuntas"
+    ],
     "name:nld_x_preferred":[
+        "Adjuntas"
+    ],
+    "name:pol_x_preferred":[
         "Adjuntas"
     ],
     "name:por_x_preferred":[
         "Adjuntas"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0434\u0445\u0443\u043d\u0442\u0430\u0441"
     ],
     "name:scn_x_preferred":[
         "Adjuntas"
@@ -139,7 +160,7 @@
         "wd:id":"Q1864884"
     },
     "wof:country":"PR",
-    "wof:geomhash":"a530800eb07d74d8c6a781ccab89cc75",
+    "wof:geomhash":"2d211c0fbb5dd42d25cb15d401ea2fdb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -160,7 +181,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476301,
+    "wof:lastmodified":1690855864,
     "wof:name":"Adjuntas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/397/102080397.geojson
+++ b/data/102/080/397/102080397.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u06cc\u0627\u0648\u06a9\u0648"
+    ],
     "name:bpy_x_preferred":[
         "\u09af\u09bc\u09be\u0989\u0995\u09cb"
     ],
@@ -37,13 +40,25 @@
     "name:ceb_x_preferred":[
         "Yauco"
     ],
+    "name:deu_x_preferred":[
+        "Yauco"
+    ],
     "name:eng_x_preferred":[
         "Yauco"
     ],
     "name:eng_x_variant":[
         "Yauco Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Yauco"
+    ],
+    "name:fas_x_preferred":[
+        "\u06cc\u0627\u0648\u06a9\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Yauco"
+    ],
+    "name:gle_x_preferred":[
         "Yauco"
     ],
     "name:ita_x_preferred":[
@@ -56,6 +71,9 @@
         "Yauco"
     ],
     "name:pol_x_preferred":[
+        "Yauco"
+    ],
+    "name:por_x_preferred":[
         "Yauco"
     ],
     "name:rus_x_preferred":[
@@ -127,7 +145,7 @@
         "wd:id":"Q368526"
     },
     "wof:country":"PR",
-    "wof:geomhash":"e8695a81b565d64112acd96fdbfa8005",
+    "wof:geomhash":"178ccd17aa95f700af75e5ff335bfa5d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +166,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476308,
+    "wof:lastmodified":1690855856,
     "wof:name":"Yauco",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/401/102080401.geojson
+++ b/data/102/080/401/102080401.geojson
@@ -34,13 +34,25 @@
     "name:cat_x_preferred":[
         "Morovis"
     ],
+    "name:ceb_x_preferred":[
+        "Morovis Municipio"
+    ],
+    "name:deu_x_preferred":[
+        "Morovis"
+    ],
     "name:eng_x_preferred":[
         "Morovis"
     ],
     "name:eng_x_variant":[
         "Morovis Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0648\u0631\u0648\u06cc\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Morovis"
+    ],
+    "name:gle_x_preferred":[
         "Morovis"
     ],
     "name:hbs_x_preferred":[
@@ -52,8 +64,17 @@
     "name:jpn_x_preferred":[
         "\u30e2\u30ed\u30d3\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Morovis"
+    ],
     "name:nld_x_preferred":[
         "Morovis"
+    ],
+    "name:por_x_preferred":[
+        "Morovis"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u043e\u0440\u043e\u0432\u0438\u0441"
     ],
     "name:spa_x_preferred":[
         "Municipio Morovis"
@@ -124,7 +145,7 @@
         "wd:id":"Q2623982"
     },
     "wof:country":"PR",
-    "wof:geomhash":"d929b1bfb3ac7b3c0cc979491e39d066",
+    "wof:geomhash":"2a5b72cba90e7bbb9a8298454fcfab16",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +166,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1690855859,
     "wof:name":"Morovis",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/405/102080405.geojson
+++ b/data/102/080/405/102080405.geojson
@@ -34,13 +34,22 @@
     "name:cat_x_preferred":[
         "Jayuya"
     ],
+    "name:deu_x_preferred":[
+        "Jayuya"
+    ],
     "name:eng_x_preferred":[
         "Jayuya"
     ],
     "name:eng_x_variant":[
         "Jayuya Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u0648\u06cc\u0648\u06cc\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Jayuya"
+    ],
+    "name:gle_x_preferred":[
         "Jayuya"
     ],
     "name:hbs_x_preferred":[
@@ -58,11 +67,17 @@
     "name:jpn_x_preferred":[
         "\u30b8\u30e3\u30e6\u30e4"
     ],
+    "name:lld_x_preferred":[
+        "Jayuya"
+    ],
     "name:nld_x_preferred":[
         "Jayuya"
     ],
     "name:por_x_preferred":[
         "Jayuya"
+    ],
+    "name:rus_x_preferred":[
+        "\u0425\u0430\u044e\u044f"
     ],
     "name:spa_x_preferred":[
         "Municipio Jayuya"
@@ -133,7 +148,7 @@
         "wd:id":"Q2095818"
     },
     "wof:country":"PR",
-    "wof:geomhash":"e383e810219b8a0df545e67ec63d7390",
+    "wof:geomhash":"0a1f773933d211a93267c05f8507a5d8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +169,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1690855868,
     "wof:name":"Jayuya",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/407/102080407.geojson
+++ b/data/102/080/407/102080407.geojson
@@ -37,13 +37,22 @@
     "name:ceb_x_preferred":[
         "Hormigueros"
     ],
+    "name:deu_x_preferred":[
+        "Hormigueros"
+    ],
     "name:eng_x_preferred":[
         "Hormigueros"
     ],
     "name:eng_x_variant":[
         "Hormigueros Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0647\u0648\u0631\u0645\u06cc\u06af\u0648\u0626\u0631\u0648\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Hormigueros"
+    ],
+    "name:gle_x_preferred":[
         "Hormigueros"
     ],
     "name:ita_x_preferred":[
@@ -51,6 +60,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30aa\u30eb\u30df\u30b0\u30a8\u30ed\u30b9"
+    ],
+    "name:lld_x_preferred":[
+        "Hormigueros"
     ],
     "name:nld_x_preferred":[
         "Hormigueros"
@@ -127,7 +139,7 @@
         "wd:id":"Q2361536"
     },
     "wof:country":"PR",
-    "wof:geomhash":"cc21ff8d7999847812e98f22ca30633b",
+    "wof:geomhash":"926f1a2476ed6fca1638d3468ed5f19d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +160,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1690855860,
     "wof:name":"Hormigueros",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/413/102080413.geojson
+++ b/data/102/080/413/102080413.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u0648\u0642\u0627 \u0622\u0644\u062a\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u09ad\u09c7\u0997\u09be \u0986\u09b2\u099f\u09be"
     ],
@@ -35,6 +38,9 @@
         "Vega Alta"
     ],
     "name:ceb_x_preferred":[
+        "Vega Alta"
+    ],
+    "name:deu_x_preferred":[
         "Vega Alta"
     ],
     "name:eng_x_preferred":[
@@ -52,6 +58,9 @@
     "name:fra_x_preferred":[
         "Vega Alta"
     ],
+    "name:gle_x_preferred":[
+        "Vega Alta"
+    ],
     "name:hbs_x_preferred":[
         "Vega Alta"
     ],
@@ -61,11 +70,20 @@
     "name:jpn_x_preferred":[
         "\u30d9\u30ac\u30fb\u30a2\u30eb\u30bf"
     ],
+    "name:lld_x_preferred":[
+        "Vega Alta"
+    ],
     "name:nld_x_preferred":[
         "Vega Alta"
     ],
     "name:pol_x_preferred":[
         "Vega Alta"
+    ],
+    "name:por_x_preferred":[
+        "Vega Alta"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u0435\u0433\u0430-\u0410\u043b\u044c\u0442\u0430"
     ],
     "name:scn_x_preferred":[
         "Vega Alta"
@@ -139,7 +157,7 @@
         "wd:id":"Q2640843"
     },
     "wof:country":"PR",
-    "wof:geomhash":"07e847a39f6caad066f13dff2612e204",
+    "wof:geomhash":"4a6d2a8f17d93cc0f0282679ecd5ca0e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -160,7 +178,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1690855857,
     "wof:name":"Vega Alta",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/415/102080415.geojson
+++ b/data/102/080/415/102080415.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ara_x_preferred":[
+        "\u062e\u0648\u0627\u0646\u0627 \u062f\u064a\u0627\u0632"
+    ],
     "name:bpy_x_preferred":[
         "\u099c\u09c1\u09af\u09bc\u09be\u09a8\u09be \u09a1\u09bf\u09af\u09bc\u09be\u099c"
     ],
@@ -40,13 +43,22 @@
     "name:ces_x_preferred":[
         "Juana D\u00edaz"
     ],
+    "name:deu_x_preferred":[
+        "Juana D\u00edaz"
+    ],
     "name:eng_x_preferred":[
         "Juana D\u00edaz"
     ],
     "name:eng_x_variant":[
         "Juana D\u00edaz Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u062e\u0648\u0627\u0646\u0627 \u062f\u06cc\u0627\u0632"
+    ],
     "name:fra_x_preferred":[
+        "Juana D\u00edaz"
+    ],
+    "name:gle_x_preferred":[
         "Juana D\u00edaz"
     ],
     "name:ita_x_preferred":[
@@ -63,6 +75,9 @@
     ],
     "name:por_x_preferred":[
         "Juana D\u00edaz"
+    ],
+    "name:rus_x_preferred":[
+        "\u0425\u0443\u0430\u043d\u0430-\u0414\u0438\u0430\u0441"
     ],
     "name:slk_x_preferred":[
         "Juana D\u00edaz"
@@ -130,7 +145,7 @@
         "wd:id":"Q2361577"
     },
     "wof:country":"PR",
-    "wof:geomhash":"b74ddaa3d3ed80cb504578d27595db16",
+    "wof:geomhash":"a61de7eb5befd5fab3a92baa2b31a895",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +166,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855858,
     "wof:name":"Juana D\u00edaz",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/417/102080417.geojson
+++ b/data/102/080/417/102080417.geojson
@@ -70,6 +70,12 @@
     "name:ces_x_preferred":[
         "Souhv\u011bzd\u00ed Me\u010douna"
     ],
+    "name:ces_x_variant":[
+        "Me\u010doun"
+    ],
+    "name:cor_x_preferred":[
+        "Dorado"
+    ],
     "name:cos_x_preferred":[
         "Dorado"
     ],
@@ -81,6 +87,9 @@
     ],
     "name:deu_x_preferred":[
         "Schwertfisch"
+    ],
+    "name:diq_x_preferred":[
+        "Q\u0131lincmase"
     ],
     "name:ell_x_preferred":[
         "\u0394\u03bf\u03c1\u03ac\u03c2"
@@ -175,8 +184,14 @@
     "name:msa_x_preferred":[
         "Todak"
     ],
+    "name:mya_x_preferred":[
+        "\u1012\u102d\u102f\u101b\u1012\u102d\u102f"
+    ],
     "name:nan_x_preferred":[
         "K\u00ee-h\u00ee-ch\u014d"
+    ],
+    "name:nds_x_preferred":[
+        "Swertfisch"
     ],
     "name:nld_x_preferred":[
         "Goudvis"
@@ -250,6 +265,9 @@
     "name:war_x_preferred":[
         "Dorado"
     ],
+    "name:wuu_x_preferred":[
+        "\u5251\u9c7c\u5ea7"
+    ],
     "name:yue_x_preferred":[
         "\u528d\u9b5a\u5ea7"
     ],
@@ -301,7 +319,7 @@
         "wd:id":"Q8837"
     },
     "wof:country":"PR",
-    "wof:geomhash":"e25ca7e3a954cf51db1a9eaf5920ac60",
+    "wof:geomhash":"6fc06e1f0566785625c50fcd1f61043f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -322,7 +340,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1690855865,
     "wof:name":"Dorado",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/419/102080419.geojson
+++ b/data/102/080/419/102080419.geojson
@@ -40,13 +40,25 @@
     "name:dan_x_preferred":[
         "Cayey"
     ],
+    "name:deu_x_preferred":[
+        "Cayey"
+    ],
     "name:eng_x_preferred":[
         "Cayey"
     ],
     "name:eng_x_variant":[
         "Cayey Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Cayey"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u06cc\u0626\u06cc"
+    ],
     "name:fra_x_preferred":[
+        "Cayey"
+    ],
+    "name:gle_x_preferred":[
         "Cayey"
     ],
     "name:heb_x_preferred":[
@@ -57,6 +69,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ab\u30b8\u30a7\u30a4"
+    ],
+    "name:lld_x_preferred":[
+        "Cayey"
     ],
     "name:nld_x_preferred":[
         "Cayey"
@@ -136,7 +151,7 @@
         "wd:id":"Q2307508"
     },
     "wof:country":"PR",
-    "wof:geomhash":"5f74ae4e3449d66d216014c4361b550d",
+    "wof:geomhash":"6d8011f46a41477e4cf40a7cd28972f3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +172,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1690855865,
     "wof:name":"Cayey",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/425/102080425.geojson
+++ b/data/102/080/425/102080425.geojson
@@ -31,6 +31,15 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u063a\u0648\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u062c\u0648\u0627\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Caguas"
+    ],
+    "name:bel_x_preferred":[
+        "\u041a\u0430\u0433\u0443\u0430\u0441"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u0997\u09cb\u09af\u09bc\u09be\u09b8"
     ],
@@ -64,10 +73,16 @@
     "name:epo_x_preferred":[
         "Caguas"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u06af\u0648\u0627\u0633"
+    ],
     "name:fin_x_preferred":[
         "Caguas"
     ],
     "name:fra_x_preferred":[
+        "Caguas"
+    ],
+    "name:gle_x_preferred":[
         "Caguas"
     ],
     "name:guj_x_preferred":[
@@ -94,6 +109,9 @@
     "name:kan_x_preferred":[
         "\u0c95\u0cc1\u0c97\u0cbe\u0cb8\u0ccd"
     ],
+    "name:kat_x_preferred":[
+        "\u10d9\u10d0\u10d2\u10e3\u10d0\u10e1\u10d8"
+    ],
     "name:kaz_x_preferred":[
         "\u041a\u0430\u0433\u0443\u0430\u0441"
     ],
@@ -105,6 +123,9 @@
     ],
     "name:lit_x_preferred":[
         "Kaguasas"
+    ],
+    "name:lld_x_preferred":[
+        "Caguas"
     ],
     "name:mar_x_preferred":[
         "\u0915\u0945\u0917\u0941\u0938"
@@ -127,6 +148,9 @@
     "name:por_x_preferred":[
         "Caguas"
     ],
+    "name:ron_x_preferred":[
+        "Caguas"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u0430\u0433\u0443\u0430\u0441"
     ],
@@ -144,6 +168,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0433\u0432\u0430\u0441"
+    ],
+    "name:swa_x_preferred":[
+        "Caguas"
     ],
     "name:swe_x_preferred":[
         "Caguas"
@@ -217,7 +244,7 @@
         "wd:id":"Q527268"
     },
     "wof:country":"PR",
-    "wof:geomhash":"5efe12423a19a2dd7ed19f18e29f15ad",
+    "wof:geomhash":"e4869ad886bb8c30663bd2eea1b83846",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -238,7 +265,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1690855857,
     "wof:name":"Caguas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/427/102080427.geojson
+++ b/data/102/080/427/102080427.geojson
@@ -37,13 +37,22 @@
     "name:ceb_x_preferred":[
         "Orocovis"
     ],
+    "name:deu_x_preferred":[
+        "Orocovis"
+    ],
     "name:eng_x_preferred":[
         "Orocovis"
     ],
     "name:eng_x_variant":[
         "Orocovis Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0648\u0631\u0627\u0633\u0648\u0648\u06cc\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Orocovis"
+    ],
+    "name:gle_x_preferred":[
         "Orocovis"
     ],
     "name:hbs_x_preferred":[
@@ -55,11 +64,17 @@
     "name:jpn_x_preferred":[
         "\u30aa\u30ed\u30b3\u30d3\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Orocovis"
+    ],
     "name:nld_x_preferred":[
         "Orocovis"
     ],
     "name:por_x_preferred":[
         "Orocovis"
+    ],
+    "name:rus_x_preferred":[
+        "\u041e\u0440\u043e\u043a\u043e\u0432\u0438\u0441"
     ],
     "name:spa_x_preferred":[
         "Municipio Orocovis"
@@ -130,7 +145,7 @@
         "wd:id":"Q2624345"
     },
     "wof:country":"PR",
-    "wof:geomhash":"9d85aeae119fdab2c1209a6eeecec328",
+    "wof:geomhash":"ce2095703b3d0289dc731d738e318b17",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +166,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1690855867,
     "wof:name":"Orocovis",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/429/102080429.geojson
+++ b/data/102/080/429/102080429.geojson
@@ -49,7 +49,13 @@
     "name:epo_x_preferred":[
         "Gu\u00e1nica"
     ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0627\u0646\u06cc\u06a9\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Gu\u00e1nica"
+    ],
+    "name:gle_x_preferred":[
         "Gu\u00e1nica"
     ],
     "name:ita_x_preferred":[
@@ -66,6 +72,9 @@
     ],
     "name:por_x_preferred":[
         "Gu\u00e1nica"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0443\u0430\u043d\u0438\u043a\u0430"
     ],
     "name:spa_x_preferred":[
         "Municipio Gu\u00e1nica"
@@ -131,7 +140,7 @@
         "wd:id":"Q1019645"
     },
     "wof:country":"PR",
-    "wof:geomhash":"47d3e18e5aedd0329efd1f87ffe2601a",
+    "wof:geomhash":"0ea78089a33bacdddd81ea84161c174d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -152,7 +161,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1690855866,
     "wof:name":"Gu\u00e1nica",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/431/102080431.geojson
+++ b/data/102/080/431/102080431.geojson
@@ -28,10 +28,19 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u0622\u06cc\u0628\u0648\u0646\u06cc\u062a\u0648"
+    ],
+    "name:bpy_x_preferred":[
+        "\u0986\u0987\u09ac\u09cb\u09a8\u09bf\u09a4\u09cb"
+    ],
     "name:cat_x_preferred":[
         "Aibonito"
     ],
     "name:ceb_x_preferred":[
+        "Aibonito"
+    ],
+    "name:deu_x_preferred":[
         "Aibonito"
     ],
     "name:eng_x_preferred":[
@@ -40,6 +49,9 @@
     "name:eng_x_variant":[
         "Aibonito Municipality"
     ],
+    "name:epo_x_preferred":[
+        "Aibonito"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0628\u0627\u0646\u06cc\u062a\u0648\u060c \u067e\u0648\u0631\u062a\u0648\u0631\u06cc\u06a9\u0648"
     ],
@@ -47,6 +59,9 @@
         "\u0627\u06cc\u0628\u0627\u0646\u06cc\u062a\u0648"
     ],
     "name:fra_x_preferred":[
+        "Aibonito"
+    ],
+    "name:gle_x_preferred":[
         "Aibonito"
     ],
     "name:hbs_x_preferred":[
@@ -58,6 +73,9 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30a4\u30dc\u30cb\u30c8"
     ],
+    "name:lld_x_preferred":[
+        "Aibonito"
+    ],
     "name:nld_x_preferred":[
         "Aibonito"
     ],
@@ -66,6 +84,9 @@
     ],
     "name:por_x_preferred":[
         "Aibonito"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0439\u0431\u043e\u043d\u0438\u0442\u043e"
     ],
     "name:scn_x_preferred":[
         "Aibonito"
@@ -136,7 +157,7 @@
         "wd:id":"Q2485628"
     },
     "wof:country":"PR",
-    "wof:geomhash":"3448e9c366342845ad483264a100afff",
+    "wof:geomhash":"422cb25241d1f971e627746936f9cb14",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +178,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1690855860,
     "wof:name":"Aibonito",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/433/102080433.geojson
+++ b/data/102/080/433/102080433.geojson
@@ -28,6 +28,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:azb_x_preferred":[
+        "\u0627\u0648\u062a\u0648\u0627\u062f\u0648"
+    ],
     "name:bpy_x_preferred":[
         "\u0989\u099f\u09c1\u09f1\u09be\u09a6\u09be"
     ],
@@ -37,20 +40,38 @@
     "name:ceb_x_preferred":[
         "Utuado"
     ],
+    "name:deu_x_preferred":[
+        "Utuado"
+    ],
     "name:eng_x_preferred":[
         "Utuado"
     ],
     "name:eng_x_variant":[
         "Utuado Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0648\u062a\u0627\u062f\u0648"
+    ],
     "name:fra_x_preferred":[
         "Utuado"
+    ],
+    "name:gle_x_preferred":[
+        "Utuado"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d5\u05d8\u05d5\u05d0\u05d3\u05d5"
     ],
     "name:ita_x_preferred":[
         "Utuado"
     ],
     "name:jpn_x_preferred":[
         "\u30a6\u30c8\u30a5\u30a2\u30fc\u30c9"
+    ],
+    "name:kor_x_preferred":[
+        "\uc6b0\ud22c\uc544\ub3c4"
+    ],
+    "name:lld_x_preferred":[
+        "Utuado"
     ],
     "name:nld_x_preferred":[
         "Utuado"
@@ -130,7 +151,7 @@
         "wd:id":"Q617096"
     },
     "wof:country":"PR",
-    "wof:geomhash":"3512d7ce03ef2f6c853cb1b9feb8da7a",
+    "wof:geomhash":"f2d730ee3b8017e8bcca7e91d629e249",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +172,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1690855868,
     "wof:name":"Utuado",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/437/102080437.geojson
+++ b/data/102/080/437/102080437.geojson
@@ -31,10 +31,19 @@
     "name:bpy_x_preferred":[
         "\u09ae\u09be\u09b0\u09bf\u0995\u09be\u0993"
     ],
+    "name:bre_x_preferred":[
+        "Maricao"
+    ],
     "name:cat_x_preferred":[
         "Maricao"
     ],
     "name:ceb_x_preferred":[
+        "Maricao"
+    ],
+    "name:ceb_x_variant":[
+        "Maricao Municipio"
+    ],
+    "name:deu_x_preferred":[
         "Maricao"
     ],
     "name:eng_x_preferred":[
@@ -43,7 +52,16 @@
     "name:eng_x_variant":[
         "Maricao Municipality"
     ],
+    "name:eus_x_preferred":[
+        "Maricao"
+    ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0631\u06cc\u06a9\u0627\u0626\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Maricao"
+    ],
+    "name:gle_x_preferred":[
         "Maricao"
     ],
     "name:ita_x_preferred":[
@@ -52,8 +70,17 @@
     "name:jpn_x_preferred":[
         "\u30de\u30ea\u30ab\u30aa"
     ],
+    "name:lld_x_preferred":[
+        "Maricao"
+    ],
     "name:nld_x_preferred":[
         "Maricao"
+    ],
+    "name:por_x_preferred":[
+        "Maricao"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u0440\u0438\u043a\u0430\u043e"
     ],
     "name:spa_x_preferred":[
         "Municipio Maricao"
@@ -118,7 +145,7 @@
         "wd:id":"Q2624359"
     },
     "wof:country":"PR",
-    "wof:geomhash":"2e9fef1cc903c55950d8411fe7af4907",
+    "wof:geomhash":"180bbec73a69f9458ff762addef005a0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +166,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1690855859,
     "wof:name":"Maricao",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/443/102080443.geojson
+++ b/data/102/080/443/102080443.geojson
@@ -31,6 +31,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u064a\u0627\u0645\u0648\u0646"
     ],
+    "name:azb_x_preferred":[
+        "\u0628\u0627\u06cc\u0627\u0645\u0648\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "Bayamon"
+    ],
     "name:bpy_x_preferred":[
         "\u09ac\u09be\u09af\u09bc\u09be\u09ae\u09a8"
     ],
@@ -70,6 +76,12 @@
     "name:fra_x_preferred":[
         "Bayam\u00f3n"
     ],
+    "name:gle_x_preferred":[
+        "Bayam\u00f3n"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d0\u05d9\u05d0\u05de\u05d5\u05df"
+    ],
     "name:hin_x_preferred":[
         "\u092c\u092f\u093e\u092e\u094b\u0902"
     ],
@@ -84,6 +96,9 @@
     ],
     "name:lit_x_preferred":[
         "Bajamonas"
+    ],
+    "name:lld_x_preferred":[
+        "Bayam\u00f3n"
     ],
     "name:mkd_x_preferred":[
         "\u0411\u0430\u0458\u0430\u043c\u043e\u043d"
@@ -112,6 +127,9 @@
     "name:srp_x_preferred":[
         "\u0411\u0430\u0458\u0430\u043c\u043e\u043d"
     ],
+    "name:swa_x_preferred":[
+        "Bayam\u00f3n"
+    ],
     "name:swe_x_preferred":[
         "Bayam\u00f3n"
     ],
@@ -132,6 +150,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u963f\u8499"
+    ],
+    "name:zho_x_variant":[
+        "\u5df4\u4e9a\u8499"
     ],
     "qs:a0":"Puerto Rico",
     "qs:a1_lc":"72",
@@ -175,7 +196,7 @@
         "wd:id":"Q739675"
     },
     "wof:country":"PR",
-    "wof:geomhash":"28e52feee7036135cbf35e0913638a1b",
+    "wof:geomhash":"9d85db20a37bf858e3b14f5f6ef45962",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -196,7 +217,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1690855866,
     "wof:name":"Bayam\u00f3n",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/445/102080445.geojson
+++ b/data/102/080/445/102080445.geojson
@@ -37,13 +37,22 @@
     "name:ceb_x_preferred":[
         "Patillas"
     ],
+    "name:deu_x_preferred":[
+        "Patillas"
+    ],
     "name:eng_x_preferred":[
         "Patillas"
     ],
     "name:eng_x_variant":[
         "Patillas Municipality"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0627\u062a\u06cc\u0644\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Patillas"
+    ],
+    "name:gle_x_preferred":[
         "Patillas"
     ],
     "name:ita_x_preferred":[
@@ -52,11 +61,17 @@
     "name:jpn_x_preferred":[
         "\u30d1\u30c6\u30a3\u30ea\u30e3\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Patillas"
+    ],
     "name:nld_x_preferred":[
         "Patillas"
     ],
     "name:por_x_preferred":[
         "Patillas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0430\u0442\u0438\u043b\u044c\u044f\u0441"
     ],
     "name:spa_x_preferred":[
         "Municipio Patillas"
@@ -121,7 +136,7 @@
         "wd:id":"Q2485638"
     },
     "wof:country":"PR",
-    "wof:geomhash":"ee48c9ffedb11b66801e74f8f10d1a54",
+    "wof:geomhash":"f6aad7dcc332f72b748f3d0706fa9675",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +157,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1690855867,
     "wof:name":"Patillas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/556/219/102556219.geojson
+++ b/data/102/556/219/102556219.geojson
@@ -20,6 +20,9 @@
     "name:ceb_x_preferred":[
         "Rafael Hernandez Airport"
     ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Rafael Hern\u00e1ndez"
+    ],
     "name:deu_x_preferred":[
         "Rafael Hern\u00e1ndez Airport"
     ],
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":102556219,
-    "wof:lastmodified":1566600188,
+    "wof:lastmodified":1690855854,
     "wof:name":"Aeropuerto Rafael Hern\u00edndez",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/102/556/223/102556223.geojson
+++ b/data/102/556/223/102556223.geojson
@@ -17,6 +17,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u0641\u0631\u0646\u0627\u0646\u062f\u0648 \u0644\u0648\u064a\u0633 \u0631\u064a\u0628\u0627\u0633 \u062f\u0648\u0645\u064a\u0646\u064a\u062a\u0634\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Fernando Luis Ribas Dominicci Airport"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0444\u0440\u043d\u043e\u043d\u0434\u0443 \u043b\u04ef\u0439\u0435\u0441 \u0440\u0438\u0431\u043e\u0441 \u0434\u0443\u043c\u0438\u043d\u0438\u0441\u0438"
+    ],
+    "name:zho_x_preferred":[
+        "Isla Grande \u673a\u573a"
     ],
     "oa:elevation_ft":"10",
     "oa:type":"medium_airport",
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":102556223,
-    "wof:lastmodified":1566600188,
+    "wof:lastmodified":1690855854,
     "wof:name":"Isla Grande Airport",
     "wof:parent_id":85859555,
     "wof:placetype":"campus",

--- a/data/102/556/229/102556229.geojson
+++ b/data/102/556/229/102556229.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u0645\u064a\u0631\u0633\u064a\u062f\u064a\u062a\u0627"
+    ],
     "name:ceb_x_preferred":[
         "Mercedita Airport"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":102556229,
-    "wof:lastmodified":1566600188,
+    "wof:lastmodified":1690855853,
     "wof:name":"Aeropuerto Mercedita",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/102/556/235/102556235.geojson
+++ b/data/102/556/235/102556235.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u062c\u0648\u0627\u0631\u0628\u0649 \u0628\u0648\u0644 \u0627\u0646\u0637\u0648\u0646\u064a\u0648"
+    ],
     "name:eng_x_preferred":[
         "Antonio"
     ],
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":102556235,
-    "wof:lastmodified":1566600188,
+    "wof:lastmodified":1690855854,
     "wof:name":"Antonio Nery Juarbe Pol Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/102/556/237/102556237.geojson
+++ b/data/102/556/237/102556237.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u0628\u0646\u062c\u0627\u0645\u064a\u0646 \u0631\u064a\u0641\u064a\u0631\u0627 \u0646\u0648\u0631\u064a\u064a\u062c\u0627"
+    ],
     "name:ceb_x_preferred":[
         "Benjam\u00edn Rivera Noriega Airport"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":102556237,
-    "wof:lastmodified":1566600188,
+    "wof:lastmodified":1690855855,
     "wof:name":"Culebra Airport",
     "wof:parent_id":101919287,
     "wof:placetype":"campus",

--- a/data/112/577/104/7/1125771047.geojson
+++ b/data/112/577/104/7/1125771047.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ceb_x_preferred":[
+        "Santo Domingo"
+    ],
     "name:eng_x_preferred":[
         "Santo Domingo"
     ],
@@ -32,6 +35,9 @@
         "Santo Domingo"
     ],
     "name:nld_x_preferred":[
+        "Santo Domingo"
+    ],
+    "name:spa_x_preferred":[
         "Santo Domingo"
     ],
     "name:srp_x_preferred":[
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":1125771047,
-    "wof:lastmodified":1636502708,
+    "wof:lastmodified":1690855916,
     "wof:name":"Santo Domingo",
     "wof:parent_id":102080319,
     "wof:placetype":"locality",

--- a/data/112/577/106/3/1125771063.geojson
+++ b/data/112/577/106/3/1125771063.geojson
@@ -22,10 +22,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ceb_x_preferred":[
+        "Su\u00e1rez"
+    ],
     "name:eng_x_preferred":[
         "Su\u00e1rez"
     ],
     "name:nld_x_preferred":[
+        "Su\u00e1rez"
+    ],
+    "name:spa_x_preferred":[
         "Su\u00e1rez"
     ],
     "name:srp_x_preferred":[
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":1125771063,
-    "wof:lastmodified":1566600367,
+    "wof:lastmodified":1690855917,
     "wof:name":"Suarez",
     "wof:parent_id":102080363,
     "wof:placetype":"locality",

--- a/data/112/577/307/5/1125773075.geojson
+++ b/data/112/577/307/5/1125773075.geojson
@@ -20,10 +20,16 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ceb_x_preferred":[
+        "R\u00edo Grande Barrio"
+    ],
     "name:eng_x_preferred":[
         "R\u00edo Grande"
     ],
     "name:fra_x_preferred":[
+        "R\u00edo Grande"
+    ],
+    "name:nld_x_preferred":[
         "R\u00edo Grande"
     ],
     "name:spa_x_preferred":[
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":1125773075,
-    "wof:lastmodified":1566600366,
+    "wof:lastmodified":1690855916,
     "wof:name":"R\u00edo Grande",
     "wof:parent_id":102080307,
     "wof:placetype":"locality",

--- a/data/112/580/462/5/1125804625.geojson
+++ b/data/112/580/462/5/1125804625.geojson
@@ -31,10 +31,19 @@
     "name:ceb_x_preferred":[
         "Pe\u00f1uelas Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
     "name:eng_x_preferred":[
         "Pe\u00f1uelas"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0648\u0646\u0648\u0626\u0644\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
+    "name:gle_x_preferred":[
         "Pe\u00f1uelas"
     ],
     "name:glg_x_preferred":[
@@ -49,8 +58,14 @@
     "name:nld_x_preferred":[
         "Pe\u00f1uelas"
     ],
+    "name:pol_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
     "name:por_x_preferred":[
         "Pe\u00f1uelas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0435\u043d\u044c\u044e\u044d\u043b\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Pe\u00f1uelas"
@@ -128,7 +143,7 @@
         }
     ],
     "wof:id":1125804625,
-    "wof:lastmodified":1566600349,
+    "wof:lastmodified":1690855911,
     "wof:name":"Penuelas",
     "wof:parent_id":102080335,
     "wof:placetype":"locality",

--- a/data/112/580/490/3/1125804903.geojson
+++ b/data/112/580/490/3/1125804903.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u064a\u0627\u0645\u0648\u0646"
     ],
+    "name:azb_x_preferred":[
+        "\u0628\u0627\u06cc\u0627\u0645\u0648\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "Bayamon"
+    ],
     "name:bpy_x_preferred":[
         "\u09ac\u09be\u09af\u09bc\u09be\u09ae\u09a8"
     ],
@@ -64,6 +70,12 @@
     "name:fra_x_preferred":[
         "Bayam\u00f3n"
     ],
+    "name:gle_x_preferred":[
+        "Bayam\u00f3n"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d0\u05d9\u05d0\u05de\u05d5\u05df"
+    ],
     "name:hin_x_preferred":[
         "\u092c\u092f\u093e\u092e\u094b\u0902"
     ],
@@ -78,6 +90,9 @@
     ],
     "name:lit_x_preferred":[
         "Bajamonas"
+    ],
+    "name:lld_x_preferred":[
+        "Bayam\u00f3n"
     ],
     "name:mkd_x_preferred":[
         "\u0411\u0430\u0458\u0430\u043c\u043e\u043d"
@@ -103,6 +118,9 @@
     "name:srp_x_preferred":[
         "\u0411\u0430\u0458\u0430\u043c\u043e\u043d"
     ],
+    "name:swa_x_preferred":[
+        "Bayam\u00f3n"
+    ],
     "name:swe_x_preferred":[
         "Bayam\u00f3n"
     ],
@@ -126,6 +144,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u963f\u8499"
+    ],
+    "name:zho_x_variant":[
+        "\u5df4\u4e9a\u8499"
     ],
     "qs_pg:aaroncc":"PR",
     "qs_pg:gn_country":"PR",
@@ -183,7 +204,7 @@
         }
     ],
     "wof:id":1125804903,
-    "wof:lastmodified":1566600349,
+    "wof:lastmodified":1690855911,
     "wof:name":"Bayamon",
     "wof:parent_id":102080443,
     "wof:placetype":"locality",

--- a/data/112/584/867/9/1125848679.geojson
+++ b/data/112/584/867/9/1125848679.geojson
@@ -40,7 +40,13 @@
     "name:eng_x_variant":[
         "Rinc\u00f3n"
     ],
+    "name:fas_x_preferred":[
+        "\u0631\u06cc\u0646\u0633\u0648\u0646"
+    ],
     "name:fra_x_preferred":[
+        "Rinc\u00f3n"
+    ],
+    "name:gle_x_preferred":[
         "Rinc\u00f3n"
     ],
     "name:hun_x_preferred":[
@@ -55,8 +61,14 @@
     "name:nld_x_preferred":[
         "Rinc\u00f3n"
     ],
+    "name:nob_x_preferred":[
+        "Rinc\u00f3n"
+    ],
     "name:por_x_preferred":[
         "Rinc\u00f3n"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u0438\u043d\u043a\u043e\u043d\u0430"
     ],
     "name:spa_x_preferred":[
         "Rinc\u00f3n"
@@ -138,7 +150,7 @@
         }
     ],
     "wof:id":1125848679,
-    "wof:lastmodified":1566600365,
+    "wof:lastmodified":1690855916,
     "wof:name":"Rincon",
     "wof:parent_id":102080307,
     "wof:placetype":"locality",

--- a/data/112/584/869/7/1125848697.geojson
+++ b/data/112/584/869/7/1125848697.geojson
@@ -40,7 +40,16 @@
     "name:epo_x_preferred":[
         "Rivero Granda"
     ],
+    "name:fas_x_preferred":[
+        "\u0631\u06cc\u0648 \u06af\u0631\u0627\u0646\u062f"
+    ],
     "name:fra_x_preferred":[
+        "R\u00edo Grande"
+    ],
+    "name:gle_x_preferred":[
+        "R\u00edo Grande"
+    ],
+    "name:hun_x_preferred":[
         "R\u00edo Grande"
     ],
     "name:ita_x_preferred":[
@@ -52,11 +61,17 @@
     "name:nld_x_preferred":[
         "R\u00edo Grande"
     ],
+    "name:nob_x_preferred":[
+        "R\u00edo Grande"
+    ],
     "name:pol_x_preferred":[
         "R\u00edo Grande"
     ],
     "name:por_x_preferred":[
         "R\u00edo Grande"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u0438\u043e-\u0413\u0440\u0430\u043d\u0434\u0435"
     ],
     "name:spa_x_preferred":[
         "R\u00edo Grande"
@@ -139,7 +154,7 @@
         }
     ],
     "wof:id":1125848697,
-    "wof:lastmodified":1636502708,
+    "wof:lastmodified":1690855915,
     "wof:name":"Rio Grande",
     "wof:parent_id":102080399,
     "wof:placetype":"locality",

--- a/data/112/584/969/3/1125849693.geojson
+++ b/data/112/584/969/3/1125849693.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
     "name:bpy_x_preferred":[
         "\u09b8\u09be\u09a8 \u09b8\u09c7\u09ac\u09be\u09b8\u09cd\u09a4\u09bf\u09a8"
     ],
@@ -31,13 +34,22 @@
     "name:ceb_x_preferred":[
         "San Sebasti\u00e1n Municipio"
     ],
+    "name:deu_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
     "name:eng_x_preferred":[
         "San Sebasti\u00e1n"
     ],
     "name:epo_x_preferred":[
         "Sankt-Sebastiano"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0646 \u0633\u0628\u0627\u0633\u062a\u06cc\u0646"
+    ],
     "name:fra_x_preferred":[
+        "San Sebasti\u00e1n"
+    ],
+    "name:gle_x_preferred":[
         "San Sebasti\u00e1n"
     ],
     "name:ita_x_preferred":[
@@ -54,6 +66,9 @@
     ],
     "name:por_x_preferred":[
         "San Sebasti\u00e1n"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u043d-\u0421\u0435\u0431\u0430\u0441\u0442\u044c\u044f\u043d"
     ],
     "name:spa_x_preferred":[
         "San Sebasti\u00e1n"
@@ -132,7 +147,7 @@
         }
     ],
     "wof:id":1125849693,
-    "wof:lastmodified":1566600366,
+    "wof:lastmodified":1690855916,
     "wof:name":"San Sebastian",
     "wof:parent_id":102080411,
     "wof:placetype":"locality",

--- a/data/112/585/883/5/1125858835.geojson
+++ b/data/112/585/883/5/1125858835.geojson
@@ -34,11 +34,20 @@
     "name:arg_x_preferred":[
         "San Juan"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u062e\u0648\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "San Xuan"
     ],
+    "name:azb_x_preferred":[
+        "\u0633\u0627\u0646 \u062c\u0648\u0627\u0646"
+    ],
     "name:aze_x_preferred":[
         "San Xuan"
+    ],
+    "name:aze_x_variant":[
+        "San-Xuan"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0430\u043d-\u0425\u0443\u0430\u043d"
@@ -100,6 +109,9 @@
     "name:eus_x_preferred":[
         "San Juan de Puerto Rico"
     ],
+    "name:eus_x_variant":[
+        "San Juan"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0627\u0646 \u062e\u0648\u0622\u0646"
     ],
@@ -154,6 +166,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30d5\u30a2\u30f3"
     ],
+    "name:jpn_x_variant":[
+        "\u30b5\u30f3\u30fb\u30d5\u30a2\u30f3"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0ccd\u0caf\u0cbe\u0ca8\u0ccd \u200d\u0c89\u0cb5\u0cbe\u0ca8\u0ccd"
     ],
@@ -172,6 +187,12 @@
     "name:lit_x_preferred":[
         "San Chuanas"
     ],
+    "name:lld_x_preferred":[
+        "San Juan"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d38\u0d3e\u0d7b \u0d39\u0d41\u0d35\u0d3e\u0d7b"
+    ],
     "name:mar_x_preferred":[
         "\u0938\u093e\u0928 \u0939\u0941\u0906\u0928"
     ],
@@ -179,6 +200,9 @@
         "\u0421\u0430\u043d \u0425\u0443\u0430\u043d"
     ],
     "name:mlg_x_preferred":[
+        "San Juan"
+    ],
+    "name:mlt_x_preferred":[
         "San Juan"
     ],
     "name:mon_x_preferred":[
@@ -212,6 +236,9 @@
         "\u0a38\u0a3e\u0a28 \u0a39\u0a41\u0a06\u0a28"
     ],
     "name:pap_x_preferred":[
+        "San Juan"
+    ],
+    "name:pms_x_preferred":[
         "San Juan"
     ],
     "name:pol_x_preferred":[
@@ -253,6 +280,9 @@
     "name:srp_x_preferred":[
         "\u0421\u0430\u043d \u0425\u0443\u0430\u043d"
     ],
+    "name:swa_x_preferred":[
+        "San Juan"
+    ],
     "name:swe_x_preferred":[
         "San Juan"
     ],
@@ -288,6 +318,9 @@
     ],
     "name:uzb_x_preferred":[
         "San Xuan"
+    ],
+    "name:vec_x_preferred":[
+        "San Juan"
     ],
     "name:vep_x_preferred":[
         "San Huan"
@@ -377,7 +410,7 @@
         }
     ],
     "wof:id":1125858835,
-    "wof:lastmodified":1636502707,
+    "wof:lastmodified":1690855915,
     "wof:name":"San Juan",
     "wof:parent_id":102080425,
     "wof:placetype":"locality",

--- a/data/112/587/566/1/1125875661.geojson
+++ b/data/112/587/566/1/1125875661.geojson
@@ -31,10 +31,19 @@
     "name:ceb_x_preferred":[
         "Pe\u00f1uelas Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
     "name:eng_x_preferred":[
         "Pe\u00f1uelas"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0648\u0646\u0648\u0626\u0644\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
+    "name:gle_x_preferred":[
         "Pe\u00f1uelas"
     ],
     "name:glg_x_preferred":[
@@ -49,8 +58,14 @@
     "name:nld_x_preferred":[
         "Pe\u00f1uelas"
     ],
+    "name:pol_x_preferred":[
+        "Pe\u00f1uelas"
+    ],
     "name:por_x_preferred":[
         "Pe\u00f1uelas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0435\u043d\u044c\u044e\u044d\u043b\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Pe\u00f1uelas"
@@ -127,7 +142,7 @@
         }
     ],
     "wof:id":1125875661,
-    "wof:lastmodified":1566600349,
+    "wof:lastmodified":1690855911,
     "wof:name":"Penuelas",
     "wof:parent_id":102080319,
     "wof:placetype":"locality",

--- a/data/112/587/679/9/1125876799.geojson
+++ b/data/112/587/679/9/1125876799.geojson
@@ -31,10 +31,22 @@
     "name:ceb_x_preferred":[
         "Canovanas"
     ],
+    "name:deu_x_preferred":[
+        "Can\u00f3vanas"
+    ],
     "name:eng_x_preferred":[
         "Can\u00f3vanas"
     ],
+    "name:epo_x_preferred":[
+        "Can\u00f3vanas"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0646\u0648\u0648\u0627\u0646\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Can\u00f3vanas"
+    ],
+    "name:gle_x_preferred":[
         "Can\u00f3vanas"
     ],
     "name:ita_x_preferred":[
@@ -60,6 +72,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u043d\u043e\u0432\u0430\u043d\u0430\u0441"
+    ],
+    "name:swe_x_preferred":[
+        "Can\u00f3vanas"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u043d\u043e\u0432\u0430\u043d\u0430\u0441"
@@ -131,7 +146,7 @@
         }
     ],
     "wof:id":1125876799,
-    "wof:lastmodified":1566600350,
+    "wof:lastmodified":1690855912,
     "wof:name":"Canovanas",
     "wof:parent_id":102080387,
     "wof:placetype":"locality",

--- a/data/112/588/432/9/1125884329.geojson
+++ b/data/112/588/432/9/1125884329.geojson
@@ -31,10 +31,19 @@
     "name:ceb_x_preferred":[
         "Comer\u00edo"
     ],
+    "name:deu_x_preferred":[
+        "Comer\u00edo"
+    ],
     "name:eng_x_preferred":[
         "Comer\u00edo"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0645\u0631\u06cc\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Comer\u00edo"
+    ],
+    "name:gle_x_preferred":[
         "Comer\u00edo"
     ],
     "name:ita_x_preferred":[
@@ -48,6 +57,9 @@
     ],
     "name:por_x_preferred":[
         "Comer\u00edo"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u043c\u0435\u0440\u0438\u043e"
     ],
     "name:spa_x_preferred":[
         "Comer\u00edo"
@@ -126,7 +138,7 @@
         }
     ],
     "wof:id":1125884329,
-    "wof:lastmodified":1566600347,
+    "wof:lastmodified":1690855910,
     "wof:name":"Comerio",
     "wof:parent_id":102080291,
     "wof:placetype":"locality",

--- a/data/112/588/981/3/1125889813.geojson
+++ b/data/112/588/981/3/1125889813.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0643\u0627\u0645\u0648\u064a"
+    ],
     "name:bpy_x_preferred":[
         "\u0995\u09be\u09ae\u09c1\u09af\u09bc"
     ],
@@ -31,10 +34,22 @@
     "name:ceb_x_preferred":[
         "Camuy"
     ],
+    "name:deu_x_preferred":[
+        "Camuy"
+    ],
     "name:eng_x_preferred":[
         "Camuy"
     ],
+    "name:epo_x_preferred":[
+        "Camuy"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0645\u0648\u06cc"
+    ],
     "name:fra_x_preferred":[
+        "Camuy"
+    ],
+    "name:gle_x_preferred":[
         "Camuy"
     ],
     "name:ita_x_preferred":[
@@ -43,11 +58,17 @@
     "name:jpn_x_preferred":[
         "\u30ab\u30e0\u30a4"
     ],
+    "name:lld_x_preferred":[
+        "Camuy"
+    ],
     "name:nld_x_preferred":[
         "Camuy"
     ],
     "name:por_x_preferred":[
         "Camuy"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u043c\u0443\u0439"
     ],
     "name:spa_x_preferred":[
         "Camuy"
@@ -126,7 +147,7 @@
         }
     ],
     "wof:id":1125889813,
-    "wof:lastmodified":1566600348,
+    "wof:lastmodified":1690855910,
     "wof:name":"Camuy",
     "wof:parent_id":102080293,
     "wof:placetype":"locality",

--- a/data/112/589/550/7/1125895507.geojson
+++ b/data/112/589/550/7/1125895507.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u0622\u062f\u062c\u0648\u0646\u062a\u0627\u0633"
+    ],
     "name:bpy_x_preferred":[
         "\u0985\u09cd\u09af\u09be\u09a1\u099c\u09c1\u09a8\u099f\u09be\u09b8"
     ],
@@ -31,7 +34,13 @@
     "name:ceb_x_preferred":[
         "Adjuntas"
     ],
+    "name:deu_x_preferred":[
+        "Adjuntas"
+    ],
     "name:eng_x_preferred":[
+        "Adjuntas"
+    ],
+    "name:epo_x_preferred":[
         "Adjuntas"
     ],
     "name:fas_x_preferred":[
@@ -43,17 +52,29 @@
     "name:fra_x_preferred":[
         "Adjuntas"
     ],
+    "name:gle_x_preferred":[
+        "Adjuntas"
+    ],
     "name:ita_x_preferred":[
         "Adjuntas"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30c9\u30d5\u30f3\u30bf\u30b9"
     ],
+    "name:lld_x_preferred":[
+        "Adjuntas"
+    ],
     "name:nld_x_preferred":[
+        "Adjuntas"
+    ],
+    "name:pol_x_preferred":[
         "Adjuntas"
     ],
     "name:por_x_preferred":[
         "Adjuntas"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0434\u0445\u0443\u043d\u0442\u0430\u0441"
     ],
     "name:scn_x_preferred":[
         "Adjuntas"
@@ -141,7 +162,7 @@
         }
     ],
     "wof:id":1125895507,
-    "wof:lastmodified":1566600348,
+    "wof:lastmodified":1690855910,
     "wof:name":"Adjuntas",
     "wof:parent_id":102080393,
     "wof:placetype":"locality",

--- a/data/112/590/613/9/1125906139.geojson
+++ b/data/112/590/613/9/1125906139.geojson
@@ -31,10 +31,22 @@
     "name:ceb_x_preferred":[
         "A\u00f1asco"
     ],
+    "name:deu_x_preferred":[
+        "A\u00f1asco"
+    ],
     "name:eng_x_preferred":[
         "A\u00f1asco"
     ],
+    "name:epo_x_preferred":[
+        "A\u00f1asco"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0648\u0646\u0633\u06a9\u0648"
+    ],
     "name:fra_x_preferred":[
+        "A\u00f1asco"
+    ],
+    "name:gle_x_preferred":[
         "A\u00f1asco"
     ],
     "name:ita_x_preferred":[
@@ -46,8 +58,14 @@
     "name:nld_x_preferred":[
         "A\u00f1asco"
     ],
+    "name:pol_x_preferred":[
+        "A\u00f1asco"
+    ],
     "name:por_x_preferred":[
         "A\u00f1asco"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u043d\u044c\u044f\u0441\u043a\u043e"
     ],
     "name:spa_x_preferred":[
         "A\u00f1asco"
@@ -126,7 +144,7 @@
         }
     ],
     "wof:id":1125906139,
-    "wof:lastmodified":1566600351,
+    "wof:lastmodified":1690855912,
     "wof:name":"Anasco",
     "wof:parent_id":102080323,
     "wof:placetype":"locality",

--- a/data/112/590/617/5/1125906175.geojson
+++ b/data/112/590/617/5/1125906175.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u06cc\u0627\u0628\u0648\u06a9\u0648\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u09af\u09bc\u09be\u09ac\u09c1\u0995\u09cb\u09af\u09bc\u09be"
     ],
@@ -31,13 +34,25 @@
     "name:ceb_x_preferred":[
         "Yabucoa"
     ],
+    "name:deu_x_preferred":[
+        "Yabucoa"
+    ],
     "name:eng_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:epo_x_preferred":[
         "Yabucoa"
     ],
     "name:est_x_preferred":[
         "Yabucoa"
     ],
+    "name:fas_x_preferred":[
+        "\u06cc\u0627\u0628\u0648\u0633\u0627\u0622"
+    ],
     "name:fra_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:gle_x_preferred":[
         "Yabucoa"
     ],
     "name:ita_x_preferred":[
@@ -46,8 +61,20 @@
     "name:jpn_x_preferred":[
         "\u30e4\u30d6\u30b3\u30a2"
     ],
+    "name:lld_x_preferred":[
+        "Yabucoa"
+    ],
     "name:nld_x_preferred":[
         "Yabucoa"
+    ],
+    "name:pol_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:por_x_preferred":[
+        "Yabucoa"
+    ],
+    "name:rus_x_preferred":[
+        "\u042f\u0431\u0443\u043a\u043e\u0430"
     ],
     "name:scn_x_preferred":[
         "Yabucoa"
@@ -132,7 +159,7 @@
         }
     ],
     "wof:id":1125906175,
-    "wof:lastmodified":1566600351,
+    "wof:lastmodified":1690855912,
     "wof:name":"Yabucoa",
     "wof:parent_id":102080371,
     "wof:placetype":"locality",

--- a/data/112/591/301/9/1125913019.geojson
+++ b/data/112/591/301/9/1125913019.geojson
@@ -40,7 +40,13 @@
     "name:epo_x_preferred":[
         "Gu\u00e1nica"
     ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0627\u0646\u06cc\u06a9\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Gu\u00e1nica"
+    ],
+    "name:gle_x_preferred":[
         "Gu\u00e1nica"
     ],
     "name:ita_x_preferred":[
@@ -57,6 +63,9 @@
     ],
     "name:por_x_preferred":[
         "Gu\u00e1nica"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0443\u0430\u043d\u0438\u043a\u0430"
     ],
     "name:spa_x_preferred":[
         "Gu\u00e1nica"
@@ -138,7 +147,7 @@
         }
     ],
     "wof:id":1125913019,
-    "wof:lastmodified":1566600353,
+    "wof:lastmodified":1690855914,
     "wof:name":"Guanica",
     "wof:parent_id":102080429,
     "wof:placetype":"locality",

--- a/data/112/591/484/9/1125914849.geojson
+++ b/data/112/591/484/9/1125914849.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "La Parguera"
     ],
+    "name:lld_x_preferred":[
+        "La Parguera"
+    ],
     "name:nld_x_preferred":[
         "La Parguera"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":1125914849,
-    "wof:lastmodified":1566600353,
+    "wof:lastmodified":1690855914,
     "wof:name":"Parguera",
     "wof:parent_id":102080327,
     "wof:placetype":"locality",

--- a/data/112/591/978/7/1125919787.geojson
+++ b/data/112/591/978/7/1125919787.geojson
@@ -31,10 +31,19 @@
     "name:ceb_x_preferred":[
         "Las Mar\u00edas"
     ],
+    "name:deu_x_preferred":[
+        "Las Mar\u00edas"
+    ],
     "name:eng_x_preferred":[
         "Las Mar\u00edas"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0627\u0633 \u0645\u0627\u0631\u06cc\u0627\u0633"
+    ],
     "name:fra_x_preferred":[
+        "Las Mar\u00edas"
+    ],
+    "name:gle_x_preferred":[
         "Las Mar\u00edas"
     ],
     "name:ita_x_preferred":[
@@ -48,6 +57,9 @@
     ],
     "name:por_x_preferred":[
         "Las Mar\u00edas"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u0430\u0441-\u041c\u0430\u0440\u0438\u0430\u0441"
     ],
     "name:spa_x_preferred":[
         "Las Mar\u00edas"
@@ -127,7 +139,7 @@
         }
     ],
     "wof:id":1125919787,
-    "wof:lastmodified":1566600353,
+    "wof:lastmodified":1690855914,
     "wof:name":"Las Marias",
     "wof:parent_id":102080323,
     "wof:placetype":"locality",

--- a/data/112/594/130/9/1125941309.geojson
+++ b/data/112/594/130/9/1125941309.geojson
@@ -31,10 +31,22 @@
     "name:ceb_x_preferred":[
         "Cata\u00f1o Municipio"
     ],
+    "name:deu_x_preferred":[
+        "Cata\u00f1o"
+    ],
     "name:eng_x_preferred":[
         "Cata\u00f1o"
     ],
+    "name:epo_x_preferred":[
+        "Cata\u00f1o"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u062a\u0627\u0626\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Cata\u00f1o"
+    ],
+    "name:gle_x_preferred":[
         "Cata\u00f1o"
     ],
     "name:ita_x_preferred":[
@@ -52,6 +64,9 @@
     "name:por_x_preferred":[
         "Cata\u00f1o"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u0442\u0430\u043d\u044c\u043e"
+    ],
     "name:sco_x_preferred":[
         "Cata\u00f1o"
     ],
@@ -60,6 +75,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0442\u0430\u045a\u043e"
+    ],
+    "name:swe_x_preferred":[
+        "Cata\u00f1o"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u0442\u0430\u043d\u044c\u0439\u043e"
@@ -132,7 +150,7 @@
         }
     ],
     "wof:id":1125941309,
-    "wof:lastmodified":1566600343,
+    "wof:lastmodified":1690855908,
     "wof:name":"Catano",
     "wof:parent_id":102080289,
     "wof:placetype":"locality",

--- a/data/112/594/878/1/1125948781.geojson
+++ b/data/112/594/878/1/1125948781.geojson
@@ -25,6 +25,9 @@
     "name:cat_x_preferred":[
         "Rafael Hern\u00e1ndez"
     ],
+    "name:ceb_x_preferred":[
+        "Rafael Hernandez"
+    ],
     "name:eng_x_preferred":[
         "Rafael Hern\u00e1ndez"
     ],
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":1125948781,
-    "wof:lastmodified":1566600343,
+    "wof:lastmodified":1690855908,
     "wof:name":"Rafael Hernandez",
     "wof:parent_id":102080275,
     "wof:placetype":"locality",

--- a/data/112/596/114/7/1125961147.geojson
+++ b/data/112/596/114/7/1125961147.geojson
@@ -22,8 +22,17 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0633\u0627\u0646 \u062e\u064a\u0631\u0645\u0627\u0646"
+    ],
+    "name:bpy_x_preferred":[
+        "\u09b8\u09be\u09a8 \u099c\u09be\u09b0\u09cd\u09ae\u09be\u09a8"
+    ],
     "name:cat_x_preferred":[
         "San Germ\u00e1n"
+    ],
+    "name:ceb_x_preferred":[
+        "San Germ\u00e1n Municipio"
     ],
     "name:cym_x_preferred":[
         "San Germ\u00e1n"
@@ -37,14 +46,26 @@
     "name:epo_x_preferred":[
         "San Germ\u00e1n"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0646 \u0698\u0631\u0645\u0646"
+    ],
     "name:fra_x_preferred":[
         "San Germ\u00e1n"
+    ],
+    "name:gle_x_preferred":[
+        "San Germ\u00e1n"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d0\u05df \u05d7\u05e8\u05de\u05d9\u05d0\u05df"
     ],
     "name:ita_x_preferred":[
         "San Germ\u00e1n"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30d8\u30eb\u30de\u30f3"
+    ],
+    "name:lld_x_preferred":[
+        "San Germ\u00e1n"
     ],
     "name:nld_x_preferred":[
         "San Germ\u00e1n"
@@ -144,7 +165,7 @@
         }
     ],
     "wof:id":1125961147,
-    "wof:lastmodified":1566600352,
+    "wof:lastmodified":1690855913,
     "wof:name":"San German",
     "wof:parent_id":102080357,
     "wof:placetype":"locality",

--- a/data/112/596/644/3/1125966443.geojson
+++ b/data/112/596/644/3/1125966443.geojson
@@ -34,10 +34,19 @@
     "name:dan_x_preferred":[
         "Humacao"
     ],
+    "name:deu_x_preferred":[
+        "Humacao"
+    ],
     "name:eng_x_preferred":[
         "Humacao"
     ],
+    "name:fas_x_preferred":[
+        "\u0647\u0648\u0645\u0627\u06a9\u0627\u0626\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Humacao"
+    ],
+    "name:gle_x_preferred":[
         "Humacao"
     ],
     "name:heb_x_preferred":[
@@ -49,6 +58,9 @@
     "name:jpn_x_preferred":[
         "\u30a6\u30de\u30ab\u30aa"
     ],
+    "name:lld_x_preferred":[
+        "Humacao"
+    ],
     "name:nld_x_preferred":[
         "Humacao"
     ],
@@ -56,6 +68,9 @@
         "Humacao"
     ],
     "name:por_x_preferred":[
+        "Humacao"
+    ],
+    "name:ron_x_preferred":[
         "Humacao"
     ],
     "name:rus_x_preferred":[
@@ -68,6 +83,9 @@
         "\u0423\u043c\u0430\u043a\u0430\u043e"
     ],
     "name:srp_x_variant":[
+        "Humacao"
+    ],
+    "name:szl_x_preferred":[
         "Humacao"
     ],
     "name:ukr_x_preferred":[
@@ -141,7 +159,7 @@
         }
     ],
     "wof:id":1125966443,
-    "wof:lastmodified":1566600351,
+    "wof:lastmodified":1690855913,
     "wof:name":"Humacao",
     "wof:parent_id":102080351,
     "wof:placetype":"locality",

--- a/data/112/596/825/7/1125968257.geojson
+++ b/data/112/596/825/7/1125968257.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u062a\u0648\u0627 \u0622\u0644\u062a\u0627"
+    ],
     "name:bpy_x_preferred":[
         "\u099f\u09f1\u09be \u0986\u09b2\u099f\u09be"
     ],
@@ -31,10 +34,19 @@
     "name:ceb_x_preferred":[
         "Toa Alta"
     ],
+    "name:deu_x_preferred":[
+        "Toa Alta"
+    ],
     "name:eng_x_preferred":[
         "Toa Alta"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0648\u0622 \u0622\u0644\u062a\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Toa Alta"
+    ],
+    "name:gle_x_preferred":[
         "Toa Alta"
     ],
     "name:ita_x_preferred":[
@@ -43,11 +55,17 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30a2\u30fb\u30a2\u30eb\u30bf"
     ],
+    "name:lld_x_preferred":[
+        "Toa Alta"
+    ],
     "name:nld_x_preferred":[
         "Toa Alta"
     ],
     "name:por_x_preferred":[
         "Toa Alta"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u043e\u0430-\u0410\u043b\u044c\u0442\u0430"
     ],
     "name:scn_x_preferred":[
         "Toa Alta"
@@ -132,7 +150,7 @@
         }
     ],
     "wof:id":1125968257,
-    "wof:lastmodified":1566600352,
+    "wof:lastmodified":1690855913,
     "wof:name":"Toa Alta",
     "wof:parent_id":102080359,
     "wof:placetype":"locality",

--- a/data/112/596/829/5/1125968295.geojson
+++ b/data/112/596/829/5/1125968295.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u06cc\u0627\u0648\u06a9\u0648"
+    ],
     "name:bpy_x_preferred":[
         "\u09af\u09bc\u09be\u0989\u0995\u09cb"
     ],
@@ -31,10 +34,22 @@
     "name:ceb_x_preferred":[
         "Yauco"
     ],
+    "name:deu_x_preferred":[
+        "Yauco"
+    ],
     "name:eng_x_preferred":[
         "Yauco"
     ],
+    "name:epo_x_preferred":[
+        "Yauco"
+    ],
+    "name:fas_x_preferred":[
+        "\u06cc\u0627\u0648\u06a9\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Yauco"
+    ],
+    "name:gle_x_preferred":[
         "Yauco"
     ],
     "name:ita_x_preferred":[
@@ -47,6 +62,9 @@
         "Yauco"
     ],
     "name:pol_x_preferred":[
+        "Yauco"
+    ],
+    "name:por_x_preferred":[
         "Yauco"
     ],
     "name:rus_x_preferred":[
@@ -138,7 +156,7 @@
         }
     ],
     "wof:id":1125968295,
-    "wof:lastmodified":1566600351,
+    "wof:lastmodified":1690855913,
     "wof:name":"Yauco",
     "wof:parent_id":102080397,
     "wof:placetype":"locality",

--- a/data/112/599/350/5/1125993505.geojson
+++ b/data/112/599/350/5/1125993505.geojson
@@ -37,11 +37,17 @@
     "name:eng_x_preferred":[
         "Manat\u00ed"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0646\u0627\u062a\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Manat\u00ed"
     ],
     "name:fry_x_preferred":[
         "Manati"
+    ],
+    "name:gle_x_preferred":[
+        "Manat\u00ed"
     ],
     "name:ita_x_preferred":[
         "Manat\u00ed"
@@ -54,6 +60,12 @@
     ],
     "name:pol_x_preferred":[
         "Manat\u00ed"
+    ],
+    "name:por_x_preferred":[
+        "Manat\u00ed"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u043d\u0430\u0442\u0438"
     ],
     "name:spa_x_preferred":[
         "Manat\u00ed"
@@ -135,7 +147,7 @@
         }
     ],
     "wof:id":1125993505,
-    "wof:lastmodified":1566600350,
+    "wof:lastmodified":1690855912,
     "wof:name":"Manati",
     "wof:parent_id":102080271,
     "wof:placetype":"locality",

--- a/data/112/600/608/1/1126006081.geojson
+++ b/data/112/600/608/1/1126006081.geojson
@@ -34,10 +34,19 @@
     "name:deu_x_preferred":[
         "Lo\u00edza"
     ],
+    "name:ell_x_preferred":[
+        "\u039b\u03bf\u0390\u03c3\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Lo\u00edza"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0648\u06cc\u0632\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Lo\u00edza"
+    ],
+    "name:gle_x_preferred":[
         "Lo\u00edza"
     ],
     "name:ita_x_preferred":[
@@ -45,6 +54,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ed\u30a4\u30b5"
+    ],
+    "name:lld_x_preferred":[
+        "Lo\u00edza"
     ],
     "name:nld_x_preferred":[
         "Lo\u00edza"
@@ -54,6 +66,9 @@
     ],
     "name:por_x_preferred":[
         "Lo\u00edza"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u043e\u0438\u0441\u0430"
     ],
     "name:spa_x_preferred":[
         "Lo\u00edza"
@@ -135,7 +150,7 @@
         }
     ],
     "wof:id":1126006081,
-    "wof:lastmodified":1566600357,
+    "wof:lastmodified":1690855914,
     "wof:name":"Loiza",
     "wof:parent_id":102080363,
     "wof:placetype":"locality",

--- a/data/112/602/778/3/1126027783.geojson
+++ b/data/112/602/778/3/1126027783.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u062e\u0648\u0627\u0646\u0627 \u062f\u064a\u0627\u0632"
+    ],
     "name:bpy_x_preferred":[
         "\u099c\u09c1\u09af\u09bc\u09be\u09a8\u09be \u09a1\u09bf\u09af\u09bc\u09be\u099c"
     ],
@@ -34,10 +37,19 @@
     "name:ces_x_preferred":[
         "Juana D\u00edaz"
     ],
+    "name:deu_x_preferred":[
+        "Juana D\u00edaz"
+    ],
     "name:eng_x_preferred":[
         "Juana D\u00edaz"
     ],
+    "name:fas_x_preferred":[
+        "\u062e\u0648\u0627\u0646\u0627 \u062f\u06cc\u0627\u0632"
+    ],
     "name:fra_x_preferred":[
+        "Juana D\u00edaz"
+    ],
+    "name:gle_x_preferred":[
         "Juana D\u00edaz"
     ],
     "name:ita_x_preferred":[
@@ -54,6 +66,9 @@
     ],
     "name:por_x_preferred":[
         "Juana D\u00edaz"
+    ],
+    "name:rus_x_preferred":[
+        "\u0425\u0443\u0430\u043d\u0430-\u0414\u0438\u0430\u0441"
     ],
     "name:slk_x_preferred":[
         "Juana D\u00edaz"
@@ -138,7 +153,7 @@
         }
     ],
     "wof:id":1126027783,
-    "wof:lastmodified":1566600345,
+    "wof:lastmodified":1690855909,
     "wof:name":"Juana Diaz",
     "wof:parent_id":102080415,
     "wof:placetype":"locality",

--- a/data/112/603/849/3/1126038493.geojson
+++ b/data/112/603/849/3/1126038493.geojson
@@ -31,11 +31,20 @@
     "name:arg_x_preferred":[
         "San Juan"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u062e\u0648\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "San Xuan"
     ],
+    "name:azb_x_preferred":[
+        "\u0633\u0627\u0646 \u062c\u0648\u0627\u0646"
+    ],
     "name:aze_x_preferred":[
         "San Xuan"
+    ],
+    "name:aze_x_variant":[
+        "San-Xuan"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0430\u043d-\u0425\u0443\u0430\u043d"
@@ -97,6 +106,9 @@
     "name:eus_x_preferred":[
         "San Juan de Puerto Rico"
     ],
+    "name:eus_x_variant":[
+        "San Juan"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0627\u0646 \u062e\u0648\u0622\u0646"
     ],
@@ -151,6 +163,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30d5\u30a2\u30f3"
     ],
+    "name:jpn_x_variant":[
+        "\u30b5\u30f3\u30fb\u30d5\u30a2\u30f3"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0ccd\u0caf\u0cbe\u0ca8\u0ccd \u200d\u0c89\u0cb5\u0cbe\u0ca8\u0ccd"
     ],
@@ -172,6 +187,12 @@
     "name:lit_x_preferred":[
         "San Chuanas"
     ],
+    "name:lld_x_preferred":[
+        "San Juan"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d38\u0d3e\u0d7b \u0d39\u0d41\u0d35\u0d3e\u0d7b"
+    ],
     "name:mar_x_preferred":[
         "\u0938\u093e\u0928 \u0939\u0941\u0906\u0928"
     ],
@@ -179,6 +200,9 @@
         "\u0421\u0430\u043d \u0425\u0443\u0430\u043d"
     ],
     "name:mlg_x_preferred":[
+        "San Juan"
+    ],
+    "name:mlt_x_preferred":[
         "San Juan"
     ],
     "name:mon_x_preferred":[
@@ -215,6 +239,9 @@
         "\u0a38\u0a3e\u0a28 \u0a39\u0a41\u0a06\u0a28"
     ],
     "name:pap_x_preferred":[
+        "San Juan"
+    ],
+    "name:pms_x_preferred":[
         "San Juan"
     ],
     "name:pol_x_preferred":[
@@ -256,6 +283,9 @@
     "name:srp_x_preferred":[
         "\u0421\u0430\u043d \u0425\u0443\u0430\u043d"
     ],
+    "name:swa_x_preferred":[
+        "San Juan"
+    ],
     "name:swe_x_preferred":[
         "San Juan"
     ],
@@ -295,6 +325,9 @@
     ],
     "name:uzb_x_preferred":[
         "San Xuan"
+    ],
+    "name:vec_x_preferred":[
+        "San Juan"
     ],
     "name:vep_x_preferred":[
         "San Huan"
@@ -371,7 +404,7 @@
         }
     ],
     "wof:id":1126038493,
-    "wof:lastmodified":1636502706,
+    "wof:lastmodified":1690855910,
     "wof:name":"San Juan",
     "wof:parent_id":102080441,
     "wof:placetype":"locality",

--- a/data/112/607/605/9/1126076059.geojson
+++ b/data/112/607/605/9/1126076059.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0631\u064a\u0648 \u0628\u064a\u062f\u0631\u0627\u0633"
+    ],
     "name:cat_x_preferred":[
         "R\u00edo Piedras"
     ],
@@ -41,6 +44,9 @@
         "R\u00edo Piedras"
     ],
     "name:fra_x_preferred":[
+        "R\u00edo Piedras"
+    ],
+    "name:gle_x_preferred":[
         "R\u00edo Piedras"
     ],
     "name:heb_x_preferred":[
@@ -88,6 +94,12 @@
     ],
     "name:swe_x_preferred":[
         "R\u00edo Piedras"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0420\u0456\u043e-\u041f\u0456\u0435\u0434\u0440\u0430\u0441"
+    ],
+    "name:zho_x_preferred":[
+        "\u91cc\u7ea6\u76ae\u57c3\u5fb7\u62c9\u65af\u516c\u5bd3\u9152\u5e97"
     ],
     "qs_pg:aaroncc":"PR",
     "qs_pg:gn_country":"PR",
@@ -147,7 +159,7 @@
         }
     ],
     "wof:id":1126076059,
-    "wof:lastmodified":1566600359,
+    "wof:lastmodified":1690855915,
     "wof:name":"Rio Piedras",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/112/610/578/9/1126105789.geojson
+++ b/data/112/610/578/9/1126105789.geojson
@@ -22,10 +22,19 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ceb_x_preferred":[
+        "Miramar Subbarrio"
+    ],
     "name:eng_x_preferred":[
         "Miramar"
     ],
     "name:fra_x_preferred":[
+        "Miramar"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30df\u30e9\u30de\u30fc"
+    ],
+    "name:nld_x_preferred":[
         "Miramar"
     ],
     "name:spa_x_preferred":[
@@ -89,7 +98,7 @@
         }
     ],
     "wof:id":1126105789,
-    "wof:lastmodified":1566600345,
+    "wof:lastmodified":1690855909,
     "wof:name":"Miramar",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/114/190/837/5/1141908375.geojson
+++ b/data/114/190/837/5/1141908375.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-67.1397109392,18.201510436,-67.1397109392,18.201510436",
+    "geom:bbox":"-67.139711,18.20151,-67.139711,18.20151",
     "geom:latitude":18.20151,
     "geom:longitude":-67.139711,
     "gn:country":"PR",
@@ -23,6 +23,9 @@
     "mz:min_zoom":8.0,
     "name:ara_x_preferred":[
         "\u0645\u0627\u064a\u0627\u062c\u0648\u064a\u0632"
+    ],
+    "name:azb_x_preferred":[
+        "\u0645\u0627\u06cc\u0627\u0642\u0648\u0632"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09af\u09bc\u09be\u0997\u09cb\u09af\u09bc\u09c7\u099c"
@@ -54,6 +57,12 @@
     "name:eng_x_preferred":[
         "Mayag\u00fcez"
     ],
+    "name:epo_x_preferred":[
+        "Mayag\u00fcez"
+    ],
+    "name:eus_x_preferred":[
+        "Mayag\u00fcez"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u06af\u0648\u0626\u0632"
     ],
@@ -61,6 +70,9 @@
         "Mayag\u00fcez"
     ],
     "name:fra_x_preferred":[
+        "Mayag\u00fcez"
+    ],
+    "name:gle_x_preferred":[
         "Mayag\u00fcez"
     ],
     "name:glg_x_preferred":[
@@ -98,6 +110,9 @@
     ],
     "name:lit_x_preferred":[
         "Majaguesas"
+    ],
+    "name:lld_x_preferred":[
+        "Mayag\u00fcez"
     ],
     "name:mar_x_preferred":[
         "\u092e\u093e\u092f\u093e\u0917\u094d\u0935\u0947\u091d"
@@ -301,7 +316,7 @@
     },
     "wof:country":"PR",
     "wof:created":1499130889,
-    "wof:geomhash":"3eaf9f569941bb9f53a6bf7b3684b752",
+    "wof:geomhash":"b1b7c8c7e47745b0024bf85e0db9fe2a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -314,7 +329,7 @@
         }
     ],
     "wof:id":1141908375,
-    "wof:lastmodified":1566600418,
+    "wof:lastmodified":1690855917,
     "wof:name":"Mayaguez",
     "wof:parent_id":102080311,
     "wof:placetype":"locality",
@@ -328,10 +343,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -67.1397109391832,
-    18.20151043596167,
-    -67.1397109391832,
-    18.20151043596167
+    -67.139711,
+    18.20151,
+    -67.139711,
+    18.20151
 ],
-  "geometry": {"coordinates":[-67.1397109391832,18.20151043596167],"type":"Point"}
+  "geometry": {"coordinates":[-67.13971100000001,18.20151],"type":"Point"}
 }

--- a/data/857/988/37/85798837.geojson
+++ b/data/857/988/37/85798837.geojson
@@ -36,6 +36,9 @@
     "name:ceb_x_preferred":[
         "Aldoar"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u043b\u0434\u043e\u0430\u0440"
+    ],
     "name:deu_x_preferred":[
         "Aldoar"
     ],
@@ -68,6 +71,9 @@
     ],
     "name:spa_x_preferred":[
         "Aldoar"
+    ],
+    "name:tat_x_preferred":[
+        "\u0410\u043b\u0434\u043e\u0430\u0440"
     ],
     "name:zho_x_preferred":[
         "\u963f\u5c14\u591a\u963f\u5c14"
@@ -134,7 +140,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1582358353,
+    "wof:lastmodified":1690855872,
     "wof:name":"Aldoar",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/13/85799013.geojson
+++ b/data/857/990/13/85799013.geojson
@@ -28,6 +28,9 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
     "mz:tier_locality":3,
+    "name:che_x_preferred":[
+        "\u041b\u043e\u0440\u0434\u0435\u043b\u0443-\u0434\u0443-\u041e\u0440\u0443"
+    ],
     "name:kaz_x_preferred":[
         "\u041b\u043e\u0440\u0434\u0435\u043b\u0443-\u0434\u0443-\u041e\u0440\u0443"
     ],
@@ -35,6 +38,9 @@
         "Lordelo do Ouro"
     ],
     "name:rus_x_preferred":[
+        "\u041b\u043e\u0440\u0434\u0435\u043b\u0443-\u0434\u0443-\u041e\u0440\u0443"
+    ],
+    "name:tat_x_preferred":[
         "\u041b\u043e\u0440\u0434\u0435\u043b\u0443-\u0434\u0443-\u041e\u0440\u0443"
     ],
     "qs:gn_adm0_cc":"PT",
@@ -100,7 +106,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1582358353,
+    "wof:lastmodified":1690855872,
     "wof:name":"Lordelo do Ouro",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/29/85799029.geojson
+++ b/data/857/990/29/85799029.geojson
@@ -33,6 +33,9 @@
     "name:ceb_x_preferred":[
         "Mafamude"
     ],
+    "name:che_x_preferred":[
+        "\u041c\u0430\u0444\u0430\u043c\u0443\u0434\u0435"
+    ],
     "name:deu_x_preferred":[
         "Mafamude"
     ],
@@ -65,6 +68,9 @@
     ],
     "name:spa_x_preferred":[
         "Mafamude"
+    ],
+    "name:tat_x_preferred":[
+        "\u041c\u0430\u0444\u0430\u043c\u0443\u0434\u0435"
     ],
     "name:tur_x_preferred":[
         "Mafamude"
@@ -137,7 +143,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1582358352,
+    "wof:lastmodified":1690855872,
     "wof:name":"Mafamude",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/857/990/95/85799095.geojson
+++ b/data/857/990/95/85799095.geojson
@@ -33,6 +33,9 @@
     "name:ceb_x_preferred":[
         "Ramalde"
     ],
+    "name:che_x_preferred":[
+        "\u0420\u0430\u043c\u0430\u043b\u0434\u0435"
+    ],
     "name:deu_x_preferred":[
         "Ramalde"
     ],
@@ -71,6 +74,9 @@
     ],
     "name:spa_x_preferred":[
         "Ramalde"
+    ],
+    "name:tat_x_preferred":[
+        "\u0420\u0430\u043c\u0430\u043b\u0434\u0435"
     ],
     "name:zho_x_preferred":[
         "\u62c9\u9a6c\u5c14\u8fea"
@@ -140,7 +146,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1582358352,
+    "wof:lastmodified":1690855872,
     "wof:name":"Ramalde",
     "wof:parent_id":101752093,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/39/85859539.geojson
+++ b/data/858/595/39/85859539.geojson
@@ -53,6 +53,9 @@
     "name:spa_x_preferred":[
         "Hato Rey"
     ],
+    "name:swe_x_preferred":[
+        "Hato Rey"
+    ],
     "name:zho_x_preferred":[
         "\u54c8\u6258\u96f7\u4f0a"
     ],
@@ -120,7 +123,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582358353,
+    "wof:lastmodified":1690855873,
     "wof:name":"Hato Rey",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/43/85859543.geojson
+++ b/data/858/595/43/85859543.geojson
@@ -26,6 +26,9 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":14.0,
     "mz:tier_locality":3,
+    "name:ara_x_preferred":[
+        "\u0633\u0627\u0646\u062a\u0648\u0631\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0627\u0646\u062a\u0648\u0631\u0633"
     ],
@@ -41,10 +44,16 @@
     "name:eng_x_preferred":[
         "Santurce"
     ],
+    "name:eus_x_preferred":[
+        "Santurce"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0627\u0646\u062a\u0648\u0631\u0633"
     ],
     "name:fra_x_preferred":[
+        "Santurce"
+    ],
+    "name:gle_x_preferred":[
         "Santurce"
     ],
     "name:glg_x_preferred":[
@@ -56,6 +65,12 @@
     "name:hye_x_preferred":[
         "\u054d\u0561\u0576\u057f\u0578\u0582\u0580\u057d\u0565"
     ],
+    "name:ind_x_preferred":[
+        "Santurce"
+    ],
+    "name:ita_x_preferred":[
+        "Santurce"
+    ],
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30c8\u30a5\u30eb\u30bb"
     ],
@@ -64,6 +79,9 @@
     ],
     "name:pol_x_preferred":[
         "Santurce"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u043d\u0442\u0443\u0440\u0441\u0435"
     ],
     "name:sco_x_preferred":[
         "Santurce"
@@ -115,7 +133,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582358353,
+    "wof:lastmodified":1690855873,
     "wof:name":"Santurce",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/45/85859545.geojson
+++ b/data/858/595/45/85859545.geojson
@@ -32,11 +32,17 @@
     "name:ceb_x_preferred":[
         "San Juan Antiguo Barrio"
     ],
+    "name:ceb_x_variant":[
+        "San Juan"
+    ],
     "name:eng_x_preferred":[
         "Old San Juan Historic District"
     ],
     "name:fra_x_preferred":[
         "vieux San Juan"
+    ],
+    "name:fra_x_variant":[
+        "Vieux San Juan"
     ],
     "name:hrv_x_preferred":[
         "Stari San Juan"
@@ -53,6 +59,9 @@
     "name:por_x_preferred":[
         "San Juan/Viejo San Juan"
     ],
+    "name:rus_x_preferred":[
+        "\u0421\u0442\u0430\u0440\u044b\u0439 \u0421\u0430\u043d-\u0425\u0443\u0430\u043d"
+    ],
     "name:sco_x_preferred":[
         "Auld San Juan"
     ],
@@ -66,6 +75,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0442\u0430\u0440\u0438\u0439 \u0421\u0430\u043d-\u0425\u0443\u0430\u043d"
+    ],
+    "name:zho_x_preferred":[
+        "\u5723\u80e1\u5b89\u8001\u57ce"
     ],
     "qs:gn_adm0_cc":"PR",
     "qs:gn_id":0,
@@ -131,7 +143,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582358353,
+    "wof:lastmodified":1690855873,
     "wof:name":"Old San Juan",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/47/85859547.geojson
+++ b/data/858/595/47/85859547.geojson
@@ -32,8 +32,14 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0646\u0648\u064a\u0644 \u0641\u0631\u0646\u0627\u0646\u062f\u064a\u0632"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0646\u0648\u064a\u0644 \u0641\u0631\u0646\u0627\u0646\u062f\u064a\u0632"
+    ],
     "name:ast_x_preferred":[
         "Manuel Fern\u00e1ndez Xuncos"
+    ],
+    "name:ast_x_variant":[
+        "Manuel Fern\u00e1ndez Juncos"
     ],
     "name:cat_x_preferred":[
         "Manuel Fern\u00e1ndez Juncos"
@@ -62,6 +68,9 @@
     "name:fra_x_preferred":[
         "Manuel Fern\u00e1ndez Juncos"
     ],
+    "name:gle_x_preferred":[
+        "Manuel Fern\u00e1ndez Juncos"
+    ],
     "name:gsw_x_preferred":[
         "Manuel Fern\u00e1ndez Juncos"
     ],
@@ -87,6 +96,9 @@
         "Manuel Fern\u00e1ndez Juncos"
     ],
     "name:nob_x_preferred":[
+        "Manuel Fern\u00e1ndez Juncos"
+    ],
+    "name:pap_x_preferred":[
         "Manuel Fern\u00e1ndez Juncos"
     ],
     "name:pol_x_preferred":[
@@ -181,7 +193,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582358353,
+    "wof:lastmodified":1690855874,
     "wof:name":"Fernandez Juncos",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/51/85866251.geojson
+++ b/data/858/662/51/85866251.geojson
@@ -29,6 +29,9 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
     "mz:tier_locality":3,
+    "name:ceb_x_preferred":[
+        "Condado Subbarrio"
+    ],
     "name:eng_x_preferred":[
         "Condado"
     ],
@@ -120,7 +123,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582358355,
+    "wof:lastmodified":1690855875,
     "wof:name":"Condado",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/05/85866305.geojson
+++ b/data/858/663/05/85866305.geojson
@@ -35,7 +35,13 @@
     "name:ara_x_preferred":[
         "\u0625\u0644\u064a\u0627\u0646\u0648\u0631 \u0631\u0648\u0632\u0641\u0644\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u064a\u0627\u0646\u0648\u0631 \u0631\u0648\u0632\u0641\u0644\u062a"
+    ],
     "name:ast_x_preferred":[
+        "Eleanor Roosevelt"
+    ],
+    "name:avk_x_preferred":[
         "Eleanor Roosevelt"
     ],
     "name:azb_x_preferred":[
@@ -77,6 +83,9 @@
     "name:cym_x_preferred":[
         "Eleanor Roosevelt"
     ],
+    "name:dag_x_preferred":[
+        "Eleanor Roosevelt"
+    ],
     "name:dan_x_preferred":[
         "Eleanor Roosevelt"
     ],
@@ -116,6 +125,12 @@
     "name:glg_x_preferred":[
         "Eleanor Roosevelt"
     ],
+    "name:gsw_x_preferred":[
+        "Eleanor Roosevelt"
+    ],
+    "name:hau_x_preferred":[
+        "Eleanor Roosevelt"
+    ],
     "name:heb_x_preferred":[
         "\u05d0\u05dc\u05d9\u05e0\u05d5\u05e8 \u05e8\u05d5\u05d6\u05d5\u05d5\u05dc\u05d8"
     ],
@@ -130,6 +145,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0537\u056c\u0565\u0578\u0576\u0578\u0580 \u054c\u0578\u0582\u0566\u057e\u0565\u056c\u057f"
+    ],
+    "name:ibo_x_preferred":[
+        "Eleanor Roosevelt"
     ],
     "name:ido_x_preferred":[
         "Eleanor Roosevelt"
@@ -209,11 +227,17 @@
     "name:nob_x_preferred":[
         "Eleanor Roosevelt"
     ],
+    "name:nqo_x_preferred":[
+        "\u07cc\u07df\u07cc\u07e3\u07d0\u07d9 \u07d9\u07ce\u07db\u07dd\u07ed\u07cb\u07df\u07d5"
+    ],
     "name:oci_x_preferred":[
         "Eleanor Roosevelt"
     ],
     "name:pan_x_preferred":[
         "\u0a0f\u0a32\u0a40\u0a28\u0a4b\u0a30 \u0a30\u0a42\u0a1c\u0a35\u0a48\u0a32\u0a1f"
+    ],
+    "name:pap_x_preferred":[
+        "Eleanor Roosevelt"
     ],
     "name:pnb_x_preferred":[
         "\u0627\u0644\u06cc\u0646\u0631 \u0631\u0648\u0632\u0648\u06cc\u0644\u0679"
@@ -232,6 +256,9 @@
     ],
     "name:san_x_preferred":[
         "\u090f\u0932\u0947\u0928\u094b\u0930 \u0930\u094b\u091c\u093c\u0935\u0947\u0932\u094d\u091f"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c6e\u1c5e\u1c64\u1c71\u1c5a\u1c68 \u1c68\u1c5a\u1c61\u1c75\u1c66\u1c6e\u1c5e\u1c74"
     ],
     "name:sco_x_preferred":[
         "Eleanor Roosevelt"
@@ -269,14 +296,26 @@
     "name:ukr_x_preferred":[
         "\u0415\u043b\u0435\u043e\u043d\u043e\u0440\u0430 \u0420\u0443\u0437\u0432\u0435\u043b\u044c\u0442"
     ],
+    "name:urd_x_preferred":[
+        "\u0627\u06cc\u0644\u06cc\u0646\u0648\u0631 \u0631\u0648\u0632\u0648\u06cc\u0644\u0679"
+    ],
+    "name:uzb_x_preferred":[
+        "Eleanor Roosvelt"
+    ],
     "name:vie_x_preferred":[
         "Eleanor Roosevelt"
     ],
     "name:war_x_preferred":[
         "Eleanor Roosevelt"
     ],
+    "name:wuu_x_preferred":[
+        "\u57c3\u8389\u8bfa\u00b7\u7f57\u65af\u798f"
+    ],
     "name:yor_x_preferred":[
         "Eleanor Roosevelt"
+    ],
+    "name:yue_x_preferred":[
+        "\u611b\u84ee\u5a1c\u7f85\u65af\u798f"
     ],
     "name:zho_x_preferred":[
         "\u57c3\u8389\u8bfa\u00b7\u7f57\u65af\u798f"
@@ -367,7 +406,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582358354,
+    "wof:lastmodified":1690855874,
     "wof:name":"Eleanor Roosevelt",
     "wof:parent_id":101919427,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/25/85866325.geojson
+++ b/data/858/663/25/85866325.geojson
@@ -26,6 +26,9 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":16.0,
     "mz:tier_locality":3,
+    "name:ceb_x_preferred":[
+        "San Ant\u00f3n Barrio"
+    ],
     "name:eng_x_preferred":[
         "San Ant\u00f3n"
     ],
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1582358354,
+    "wof:lastmodified":1690855875,
     "wof:name":"San Anton",
     "wof:parent_id":101919197,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.