### PR TITLE
PR concordances, placetype local, and more

### DIFF
--- a/data/102/080/271/102080271.geojson
+++ b/data/102/080/271/102080271.geojson
@@ -147,6 +147,10 @@
         "uscensus:geoid":"72091",
         "wd:id":"Q674599"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"ec5876b85864a0c57930139635fecfa0",
     "wof:hierarchy":[
@@ -169,7 +173,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855867,
+    "wof:lastmodified":1695887195,
     "wof:name":"Manat\u00ed",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/273/102080273.geojson
+++ b/data/102/080/273/102080273.geojson
@@ -98,6 +98,10 @@
         "hasc:id":"PR.CU",
         "uscensus:geoid":"72049"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"827113efc6d92cf93e67e1f3db43cbaf",
     "wof:hierarchy":[
@@ -120,7 +124,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1695887193,
     "wof:name":"Culebra",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/275/102080275.geojson
+++ b/data/102/080/275/102080275.geojson
@@ -168,6 +168,10 @@
         "uscensus:geoid":"72005",
         "wd:id":"Q397826"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"eb791da3c36564481c0bff5e308236c9",
     "wof:hierarchy":[
@@ -190,7 +194,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855858,
+    "wof:lastmodified":1695887192,
     "wof:name":"Aguadilla",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/279/102080279.geojson
+++ b/data/102/080/279/102080279.geojson
@@ -150,6 +150,10 @@
         "uscensus:geoid":"72043",
         "wd:id":"Q1942303"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"776ef71caa7df7191d0d004f5abfa15d",
     "wof:hierarchy":[
@@ -172,7 +176,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855866,
+    "wof:lastmodified":1695887193,
     "wof:name":"Coamo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/281/102080281.geojson
+++ b/data/102/080/281/102080281.geojson
@@ -138,6 +138,10 @@
         "uscensus:geoid":"72083",
         "wd:id":"Q2485590"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"29a8e2da4a1e76b3cf71e5941c5eb8e6",
     "wof:hierarchy":[
@@ -160,7 +164,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855859,
+    "wof:lastmodified":1695887196,
     "wof:name":"Las Mar\u00edas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/283/102080283.geojson
+++ b/data/102/080/283/102080283.geojson
@@ -246,6 +246,10 @@
         "uscensus:geoid":"72013",
         "wd:id":"Q640728"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"6b697acedc369f3c403871f51c70a084",
     "wof:hierarchy":[
@@ -268,7 +272,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855865,
+    "wof:lastmodified":1695887192,
     "wof:name":"Arecibo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/285/102080285.geojson
+++ b/data/102/080/285/102080285.geojson
@@ -127,6 +127,10 @@
         "hasc:id":"PR.AR",
         "uscensus:geoid":"72015"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"a2f343aa1adcb6f5082815fbe330bcd3",
     "wof:hierarchy":[
@@ -149,7 +153,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1695887192,
     "wof:name":"Arroyo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/287/102080287.geojson
+++ b/data/102/080/287/102080287.geojson
@@ -157,6 +157,10 @@
         "uscensus:geoid":"72053",
         "wd:id":"Q542833"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"deeaf11e630f9fdba6981f47d8160d2c",
     "wof:hierarchy":[
@@ -179,7 +183,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855857,
+    "wof:lastmodified":1695887194,
     "wof:name":"Fajardo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/289/102080289.geojson
+++ b/data/102/080/289/102080289.geojson
@@ -147,6 +147,10 @@
         "uscensus:geoid":"72033",
         "wd:id":"Q768483"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:coterminous":[
         101918955
     ],
@@ -172,7 +176,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855858,
+    "wof:lastmodified":1695887193,
     "wof:name":"Cata\u00f1o",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/291/102080291.geojson
+++ b/data/102/080/291/102080291.geojson
@@ -135,6 +135,10 @@
         "uscensus:geoid":"72045",
         "wd:id":"Q2222328"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"200b8b150522f6efade15cbd20dd9113",
     "wof:hierarchy":[
@@ -157,7 +161,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855868,
+    "wof:lastmodified":1695887193,
     "wof:name":"Comer\u00edo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/293/102080293.geojson
+++ b/data/102/080/293/102080293.geojson
@@ -141,6 +141,10 @@
         "uscensus:geoid":"72027",
         "wd:id":"Q2380860"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"b476ff3f4b120f4add4f2b36628b5e38",
     "wof:hierarchy":[
@@ -163,7 +167,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855860,
+    "wof:lastmodified":1695887192,
     "wof:name":"Camuy",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/297/102080297.geojson
+++ b/data/102/080/297/102080297.geojson
@@ -141,6 +141,10 @@
         "uscensus:geoid":"72059",
         "wd:id":"Q2333093"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"b8007276e3573273aec11d4560b5c18f",
     "wof:hierarchy":[
@@ -163,7 +167,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855869,
+    "wof:lastmodified":1695887194,
     "wof:name":"Guayanilla",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/299/102080299.geojson
+++ b/data/102/080/299/102080299.geojson
@@ -116,6 +116,10 @@
         "hasc:id":"PR.PO",
         "uscensus:geoid":"72113"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"a3111af84a74805224008dc122fd75da",
     "wof:hierarchy":[
@@ -138,7 +142,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1695887197,
     "wof:name":"Ponce",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/301/102080301.geojson
+++ b/data/102/080/301/102080301.geojson
@@ -135,6 +135,10 @@
         "uscensus:geoid":"72077",
         "wd:id":"Q2347667"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"b10b5d30676c83b0483d238037c71820",
     "wof:hierarchy":[
@@ -157,7 +161,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855855,
+    "wof:lastmodified":1695887196,
     "wof:name":"Juncos",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/303/102080303.geojson
+++ b/data/102/080/303/102080303.geojson
@@ -107,6 +107,10 @@
         "hasc:id":"PR.NR",
         "uscensus:geoid":"72105"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"74cd9ba57f895a85c9823017d914c8f4",
     "wof:hierarchy":[
@@ -129,7 +133,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1695887197,
     "wof:name":"Naranjito",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/305/102080305.geojson
+++ b/data/102/080/305/102080305.geojson
@@ -159,6 +159,10 @@
         "uscensus:geoid":"72145",
         "wd:id":"Q2179051"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"f5d66261e57d813d19cfdfeae63c8d89",
     "wof:hierarchy":[
@@ -181,7 +185,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855864,
+    "wof:lastmodified":1695887199,
     "wof:name":"Vega Baja",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/307/102080307.geojson
+++ b/data/102/080/307/102080307.geojson
@@ -120,6 +120,10 @@
         "hasc:id":"PR.RC",
         "uscensus:geoid":"72117"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"31caeb1c0bcd7b8cb08065c878ddfa50",
     "wof:hierarchy":[
@@ -142,7 +146,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1695887197,
     "wof:name":"Rinc\u00f3n",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/309/102080309.geojson
+++ b/data/102/080/309/102080309.geojson
@@ -197,6 +197,10 @@
         "hasc:id":"PR.SL",
         "uscensus:geoid":"72129"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"ef9934ac0a26e0715c8ac85882855504",
     "wof:hierarchy":[
@@ -219,7 +223,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1695887198,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/311/102080311.geojson
+++ b/data/102/080/311/102080311.geojson
@@ -234,6 +234,10 @@
         "uscensus:geoid":"72097",
         "wd:id":"Q632727"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"2ca5b31d9b1744bc7f11e9d6868fd7ec",
     "wof:hierarchy":[
@@ -256,7 +260,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855869,
+    "wof:lastmodified":1695887196,
     "wof:name":"Mayag\u00fcez",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/315/102080315.geojson
+++ b/data/102/080/315/102080315.geojson
@@ -219,6 +219,10 @@
         "uscensus:geoid":"72147",
         "wd:id":"Q737624"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"0d864a112f4be85b574567e17252daf3",
     "wof:hierarchy":[
@@ -241,7 +245,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855861,
+    "wof:lastmodified":1695887199,
     "wof:name":"Vieques",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/317/102080317.geojson
+++ b/data/102/080/317/102080317.geojson
@@ -135,6 +135,10 @@
         "uscensus:geoid":"72039",
         "wd:id":"Q2485522"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"13ef0a4a99429f8bc5c9d6fbb99bf7d3",
     "wof:hierarchy":[
@@ -157,7 +161,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855871,
+    "wof:lastmodified":1695887193,
     "wof:name":"Ciales",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/319/102080319.geojson
+++ b/data/102/080/319/102080319.geojson
@@ -144,6 +144,10 @@
         "uscensus:geoid":"72111",
         "wd:id":"Q369880"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"08d8aac53d657a553234898ffabaa01e",
     "wof:hierarchy":[
@@ -166,7 +170,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855871,
+    "wof:lastmodified":1695887197,
     "wof:name":"Pe\u00f1uelas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/321/102080321.geojson
+++ b/data/102/080/321/102080321.geojson
@@ -147,6 +147,10 @@
         "uscensus:geoid":"72007",
         "wd:id":"Q2361568"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"9050a455ace35689882bb71d85286c94",
     "wof:hierarchy":[
@@ -169,7 +173,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855871,
+    "wof:lastmodified":1695887192,
     "wof:name":"Aguas Buenas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/323/102080323.geojson
+++ b/data/102/080/323/102080323.geojson
@@ -141,6 +141,10 @@
         "uscensus:geoid":"72011",
         "wd:id":"Q2390910"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"4830d4d593c28fea070bbeaac49cb235",
     "wof:hierarchy":[
@@ -163,7 +167,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855861,
+    "wof:lastmodified":1695887192,
     "wof:name":"A\u00f1asco",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/325/102080325.geojson
+++ b/data/102/080/325/102080325.geojson
@@ -147,6 +147,10 @@
         "uscensus:geoid":"72115",
         "wd:id":"Q2057872"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"d51fac8c56f44af8ce13acc73c89c45a",
     "wof:hierarchy":[
@@ -169,7 +173,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855862,
+    "wof:lastmodified":1695887197,
     "wof:name":"Quebradillas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/327/102080327.geojson
+++ b/data/102/080/327/102080327.geojson
@@ -98,6 +98,10 @@
         "hasc:id":"PR.LJ",
         "uscensus:geoid":"72079"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"d12a638128e0ce4a07bc91dd9497f10f",
     "wof:hierarchy":[
@@ -120,7 +124,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1695887196,
     "wof:name":"Lajas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/329/102080329.geojson
+++ b/data/102/080/329/102080329.geojson
@@ -153,6 +153,10 @@
         "uscensus:geoid":"72137",
         "wd:id":"Q2238070"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"4f77659511f28f88bba8252b602a8ba7",
     "wof:hierarchy":[
@@ -175,7 +179,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855869,
+    "wof:lastmodified":1695887198,
     "wof:name":"Toa Baja",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/333/102080333.geojson
+++ b/data/102/080/333/102080333.geojson
@@ -138,6 +138,10 @@
         "uscensus:geoid":"72019",
         "wd:id":"Q2485615"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"eac31a0d222c3a81c6d25d8f969d0132",
     "wof:hierarchy":[
@@ -160,7 +164,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855864,
+    "wof:lastmodified":1695887192,
     "wof:name":"Barranquitas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/335/102080335.geojson
+++ b/data/102/080/335/102080335.geojson
@@ -164,6 +164,10 @@
         "hasc:id":"PR.SI",
         "uscensus:geoid":"72133"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"54116bb1e1e23d7eac6f932377be6605",
     "wof:hierarchy":[
@@ -186,7 +190,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1695887198,
     "wof:name":"Santa Isabel",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/337/102080337.geojson
+++ b/data/102/080/337/102080337.geojson
@@ -189,6 +189,10 @@
         "hasc:id":"PR.SA",
         "uscensus:geoid":"72123"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"d47db8c47d5340cec235c1fa21543350",
     "wof:hierarchy":[
@@ -211,7 +215,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1695887197,
     "wof:name":"Salinas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/339/102080339.geojson
+++ b/data/102/080/339/102080339.geojson
@@ -141,6 +141,10 @@
         "uscensus:geoid":"72089",
         "wd:id":"Q1984618"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"fb069723f3bfb9bf8b963560b4e2842f",
     "wof:hierarchy":[
@@ -163,7 +167,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855856,
+    "wof:lastmodified":1695887196,
     "wof:name":"Luquillo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/341/102080341.geojson
+++ b/data/102/080/341/102080341.geojson
@@ -232,6 +232,10 @@
         "uscensus:geoid":"72037",
         "wd:id":"Q284019"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"416fe1573abd700949f7319eed2dfeab",
     "wof:hierarchy":[
@@ -254,7 +258,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855861,
+    "wof:lastmodified":1695887194,
     "wof:name":"Ceiba",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/343/102080343.geojson
+++ b/data/102/080/343/102080343.geojson
@@ -589,6 +589,10 @@
         "hasc:id":"PR.FL",
         "uscensus:geoid":"72054"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"34bdc8d124a2f3a679f9c7ba8d1a583d",
     "wof:hierarchy":[
@@ -611,7 +615,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1695887194,
     "wof:name":"Florida",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/345/102080345.geojson
+++ b/data/102/080/345/102080345.geojson
@@ -79,6 +79,10 @@
         "hasc:id":"PR.CD",
         "uscensus:geoid":"72041"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"a56d0c21860fd31db2071392f6359b11",
     "wof:hierarchy":[
@@ -101,7 +105,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1695887194,
     "wof:name":"Cidra",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/347/102080347.geojson
+++ b/data/102/080/347/102080347.geojson
@@ -176,6 +176,10 @@
         "hasc:id":"PR.CN",
         "uscensus:geoid":"72031"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"ddad2367e643e2bbc9fbc05253ae794b",
     "wof:hierarchy":[
@@ -198,7 +202,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1695887194,
     "wof:name":"Carolina",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/351/102080351.geojson
+++ b/data/102/080/351/102080351.geojson
@@ -150,6 +150,10 @@
         "uscensus:geoid":"72069",
         "wd:id":"Q2307535"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"8333bcde0e84b6bb63fa842129be9d9d",
     "wof:hierarchy":[
@@ -172,7 +176,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855863,
+    "wof:lastmodified":1695887195,
     "wof:name":"Humacao",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/353/102080353.geojson
+++ b/data/102/080/353/102080353.geojson
@@ -107,6 +107,10 @@
         "hasc:id":"PR.AD",
         "uscensus:geoid":"72003"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"b1b27b3e7ec29834d20c8b31273eac16",
     "wof:hierarchy":[
@@ -129,7 +133,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476301,
+    "wof:lastmodified":1695887192,
     "wof:name":"Aguada",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/355/102080355.geojson
+++ b/data/102/080/355/102080355.geojson
@@ -141,6 +141,10 @@
         "uscensus:geoid":"72103",
         "wd:id":"Q2659720"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"22c4eb37fe1b1676e69b11cb140949b3",
     "wof:hierarchy":[
@@ -163,7 +167,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855856,
+    "wof:lastmodified":1695887197,
     "wof:name":"Naguabo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/357/102080357.geojson
+++ b/data/102/080/357/102080357.geojson
@@ -159,6 +159,10 @@
         "uscensus:geoid":"72125",
         "wd:id":"Q1598808"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"db794ebe45931c70132f8c9b21a217d7",
     "wof:hierarchy":[
@@ -181,7 +185,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855863,
+    "wof:lastmodified":1695887198,
     "wof:name":"San Germ\u00e1n",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/359/102080359.geojson
+++ b/data/102/080/359/102080359.geojson
@@ -141,6 +141,10 @@
         "uscensus:geoid":"72135",
         "wd:id":"Q2485509"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"0d854ef9e88838d1b9e26733f953aadb",
     "wof:hierarchy":[
@@ -163,7 +167,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855863,
+    "wof:lastmodified":1695887198,
     "wof:name":"Toa Alta",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/361/102080361.geojson
+++ b/data/102/080/361/102080361.geojson
@@ -150,6 +150,10 @@
         "uscensus:geoid":"72139",
         "wd:id":"Q1150895"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"4533eeb028a6f09f0b8372fabd6b3eb7",
     "wof:hierarchy":[
@@ -172,7 +176,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855862,
+    "wof:lastmodified":1695887199,
     "wof:name":"Trujillo Alto",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/363/102080363.geojson
+++ b/data/102/080/363/102080363.geojson
@@ -147,6 +147,10 @@
         "uscensus:geoid":"72087",
         "wd:id":"Q1853983"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"502b4cca79f55992e6855f8fec2039d4",
     "wof:hierarchy":[
@@ -169,7 +173,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855856,
+    "wof:lastmodified":1695887196,
     "wof:name":"Lo\u00edza",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/365/102080365.geojson
+++ b/data/102/080/365/102080365.geojson
@@ -159,6 +159,10 @@
         "uscensus:geoid":"72061",
         "wd:id":"Q590060"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"5500733b08ed2daf30c8bd47043e1b2b",
     "wof:hierarchy":[
@@ -181,7 +185,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855855,
+    "wof:lastmodified":1695887195,
     "wof:name":"Guaynabo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/369/102080369.geojson
+++ b/data/102/080/369/102080369.geojson
@@ -143,6 +143,10 @@
         "hasc:id":"PR.CZ",
         "uscensus:geoid":"72047"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"6828e827dd41ffdcf180d7d1a540ccbf",
     "wof:hierarchy":[
@@ -165,7 +169,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476303,
+    "wof:lastmodified":1695887194,
     "wof:name":"Corozal",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/371/102080371.geojson
+++ b/data/102/080/371/102080371.geojson
@@ -153,6 +153,10 @@
         "uscensus:geoid":"72151",
         "wd:id":"Q2361097"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"e1ed923c202eb27fe0cde54dc835a3f3",
     "wof:hierarchy":[
@@ -175,7 +179,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855862,
+    "wof:lastmodified":1695887199,
     "wof:name":"Yabucoa",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/373/102080373.geojson
+++ b/data/102/080/373/102080373.geojson
@@ -153,6 +153,10 @@
         "uscensus:geoid":"72057",
         "wd:id":"Q1870997"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"b7ac90e900bdc52ff0e5e73d2a1ad94e",
     "wof:hierarchy":[
@@ -175,7 +179,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855870,
+    "wof:lastmodified":1695887195,
     "wof:name":"Guayama",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/375/102080375.geojson
+++ b/data/102/080/375/102080375.geojson
@@ -98,6 +98,10 @@
         "hasc:id":"PR.BC",
         "uscensus:geoid":"72017"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"0d87778a6a8012e7a39e87d3e5fb97e0",
     "wof:hierarchy":[
@@ -120,7 +124,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1695887192,
     "wof:name":"Barceloneta",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/377/102080377.geojson
+++ b/data/102/080/377/102080377.geojson
@@ -125,6 +125,10 @@
         "hasc:id":"PR.VL",
         "uscensus:geoid":"72149"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"075645bdbe7084bbe124e6f5206cc1ae",
     "wof:hierarchy":[
@@ -147,7 +151,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476308,
+    "wof:lastmodified":1695887199,
     "wof:name":"Villalba",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/379/102080379.geojson
+++ b/data/102/080/379/102080379.geojson
@@ -189,6 +189,10 @@
         "uscensus:geoid":"72081",
         "wd:id":"Q504377"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"4146cdc41f7e710c7c2b42e452fe76d4",
     "wof:hierarchy":[
@@ -211,7 +215,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855861,
+    "wof:lastmodified":1695887196,
     "wof:name":"Lares",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/381/102080381.geojson
+++ b/data/102/080/381/102080381.geojson
@@ -98,6 +98,10 @@
         "hasc:id":"PR.HA",
         "uscensus:geoid":"72065"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"134fda499bcbfc86d5fc2bebc411f21c",
     "wof:hierarchy":[
@@ -120,7 +124,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1695887195,
     "wof:name":"Hatillo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/383/102080383.geojson
+++ b/data/102/080/383/102080383.geojson
@@ -143,6 +143,10 @@
         "hasc:id":"PR.IS",
         "uscensus:geoid":"72071"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"dcfc65e05fc8cfaad44caadbcc7f7e7e",
     "wof:hierarchy":[
@@ -165,7 +169,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1695887195,
     "wof:name":"Isabela",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/387/102080387.geojson
+++ b/data/102/080/387/102080387.geojson
@@ -144,6 +144,10 @@
         "uscensus:geoid":"72029",
         "wd:id":"Q2361552"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"c59665499a81d2dc8d7b84f9f952d959",
     "wof:hierarchy":[
@@ -166,7 +170,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855870,
+    "wof:lastmodified":1695887193,
     "wof:name":"Can\u00f3vanas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/389/102080389.geojson
+++ b/data/102/080/389/102080389.geojson
@@ -135,6 +135,10 @@
         "uscensus:geoid":"72095",
         "wd:id":"Q967149"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"aac0a6552541f0315f2a3785ba25daed",
     "wof:hierarchy":[
@@ -157,7 +161,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855870,
+    "wof:lastmodified":1695887196,
     "wof:name":"Maunabo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/391/102080391.geojson
+++ b/data/102/080/391/102080391.geojson
@@ -128,6 +128,10 @@
         "hasc:id":"PR.LP",
         "uscensus:geoid":"72085"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"51def9fde23e80fb215485cd7cc538d8",
     "wof:hierarchy":[
@@ -150,7 +154,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1695887196,
     "wof:name":"Las Piedras",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/393/102080393.geojson
+++ b/data/102/080/393/102080393.geojson
@@ -159,6 +159,10 @@
         "uscensus:geoid":"72001",
         "wd:id":"Q1864884"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"2d211c0fbb5dd42d25cb15d401ea2fdb",
     "wof:hierarchy":[
@@ -181,7 +185,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855864,
+    "wof:lastmodified":1695887192,
     "wof:name":"Adjuntas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/395/102080395.geojson
+++ b/data/102/080/395/102080395.geojson
@@ -101,6 +101,10 @@
         "hasc:id":"PR.SB",
         "uscensus:geoid":"72121"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"c2db1bb532b2d31ef17d590108f19275",
     "wof:hierarchy":[
@@ -123,7 +127,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1695887197,
     "wof:name":"Sabana Grande",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/397/102080397.geojson
+++ b/data/102/080/397/102080397.geojson
@@ -144,6 +144,10 @@
         "uscensus:geoid":"72153",
         "wd:id":"Q368526"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"178ccd17aa95f700af75e5ff335bfa5d",
     "wof:hierarchy":[
@@ -166,7 +170,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855856,
+    "wof:lastmodified":1695887200,
     "wof:name":"Yauco",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/399/102080399.geojson
+++ b/data/102/080/399/102080399.geojson
@@ -81,6 +81,10 @@
         "hasc:id":"PR.RG",
         "uscensus:geoid":"72119"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"ed0e412954f953b1b0338316cd89303b",
     "wof:hierarchy":[
@@ -103,7 +107,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476306,
+    "wof:lastmodified":1695887198,
     "wof:name":"R\u00edo Grande",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/401/102080401.geojson
+++ b/data/102/080/401/102080401.geojson
@@ -144,6 +144,10 @@
         "uscensus:geoid":"72101",
         "wd:id":"Q2623982"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"2a5b72cba90e7bbb9a8298454fcfab16",
     "wof:hierarchy":[
@@ -166,7 +170,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855859,
+    "wof:lastmodified":1695887198,
     "wof:name":"Morovis",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/405/102080405.geojson
+++ b/data/102/080/405/102080405.geojson
@@ -147,6 +147,10 @@
         "uscensus:geoid":"72073",
         "wd:id":"Q2095818"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"0a1f773933d211a93267c05f8507a5d8",
     "wof:hierarchy":[
@@ -169,7 +173,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855868,
+    "wof:lastmodified":1695887195,
     "wof:name":"Jayuya",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/407/102080407.geojson
+++ b/data/102/080/407/102080407.geojson
@@ -138,6 +138,10 @@
         "uscensus:geoid":"72067",
         "wd:id":"Q2361536"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"926f1a2476ed6fca1638d3468ed5f19d",
     "wof:hierarchy":[
@@ -160,7 +164,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855860,
+    "wof:lastmodified":1695887195,
     "wof:name":"Hormigueros",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/409/102080409.geojson
+++ b/data/102/080/409/102080409.geojson
@@ -95,6 +95,10 @@
         "hasc:id":"PR.CR",
         "uscensus:geoid":"72023"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"ac90c56e0a5d25e2b990f9f3d0bd9142",
     "wof:hierarchy":[
@@ -117,7 +121,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476302,
+    "wof:lastmodified":1695887193,
     "wof:name":"Cabo Rojo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/411/102080411.geojson
+++ b/data/102/080/411/102080411.geojson
@@ -317,6 +317,10 @@
         "hasc:id":"PR.SS",
         "uscensus:geoid":"72131"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"02d53c845e444de14e1728dd6a6875be",
     "wof:hierarchy":[
@@ -339,7 +343,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1695887199,
     "wof:name":"San Sebasti\u00e1n",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/413/102080413.geojson
+++ b/data/102/080/413/102080413.geojson
@@ -156,6 +156,10 @@
         "uscensus:geoid":"72143",
         "wd:id":"Q2640843"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"4a6d2a8f17d93cc0f0282679ecd5ca0e",
     "wof:hierarchy":[
@@ -178,7 +182,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855857,
+    "wof:lastmodified":1695887199,
     "wof:name":"Vega Alta",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/415/102080415.geojson
+++ b/data/102/080/415/102080415.geojson
@@ -144,6 +144,10 @@
         "uscensus:geoid":"72075",
         "wd:id":"Q2361577"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"a61de7eb5befd5fab3a92baa2b31a895",
     "wof:hierarchy":[
@@ -166,7 +170,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855858,
+    "wof:lastmodified":1695887197,
     "wof:name":"Juana D\u00edaz",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/417/102080417.geojson
+++ b/data/102/080/417/102080417.geojson
@@ -318,6 +318,10 @@
         "uscensus:geoid":"72051",
         "wd:id":"Q8837"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"6fc06e1f0566785625c50fcd1f61043f",
     "wof:hierarchy":[
@@ -340,7 +344,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855865,
+    "wof:lastmodified":1695887194,
     "wof:name":"Dorado",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/419/102080419.geojson
+++ b/data/102/080/419/102080419.geojson
@@ -150,6 +150,10 @@
         "uscensus:geoid":"72035",
         "wd:id":"Q2307508"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"6d8011f46a41477e4cf40a7cd28972f3",
     "wof:hierarchy":[
@@ -172,7 +176,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855865,
+    "wof:lastmodified":1695887194,
     "wof:name":"Cayey",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/423/102080423.geojson
+++ b/data/102/080/423/102080423.geojson
@@ -122,6 +122,10 @@
         "hasc:id":"PR.MC",
         "uscensus:geoid":"72099"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"452ba56d33db5e02c02490c4f1af8d5f",
     "wof:hierarchy":[
@@ -144,7 +148,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476305,
+    "wof:lastmodified":1695887197,
     "wof:name":"Moca",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/425/102080425.geojson
+++ b/data/102/080/425/102080425.geojson
@@ -243,6 +243,10 @@
         "uscensus:geoid":"72025",
         "wd:id":"Q527268"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"e4869ad886bb8c30663bd2eea1b83846",
     "wof:hierarchy":[
@@ -265,7 +269,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855857,
+    "wof:lastmodified":1695887193,
     "wof:name":"Caguas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/427/102080427.geojson
+++ b/data/102/080/427/102080427.geojson
@@ -144,6 +144,10 @@
         "uscensus:geoid":"72107",
         "wd:id":"Q2624345"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"ce2095703b3d0289dc731d738e318b17",
     "wof:hierarchy":[
@@ -166,7 +170,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855867,
+    "wof:lastmodified":1695887198,
     "wof:name":"Orocovis",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/429/102080429.geojson
+++ b/data/102/080/429/102080429.geojson
@@ -139,6 +139,10 @@
         "uscensus:geoid":"72055",
         "wd:id":"Q1019645"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"0ea78089a33bacdddd81ea84161c174d",
     "wof:hierarchy":[
@@ -161,7 +165,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855866,
+    "wof:lastmodified":1695887195,
     "wof:name":"Gu\u00e1nica",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/431/102080431.geojson
+++ b/data/102/080/431/102080431.geojson
@@ -156,6 +156,10 @@
         "uscensus:geoid":"72009",
         "wd:id":"Q2485628"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"422cb25241d1f971e627746936f9cb14",
     "wof:hierarchy":[
@@ -178,7 +182,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855860,
+    "wof:lastmodified":1695887193,
     "wof:name":"Aibonito",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/433/102080433.geojson
+++ b/data/102/080/433/102080433.geojson
@@ -150,6 +150,10 @@
         "uscensus:geoid":"72141",
         "wd:id":"Q617096"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"f2d730ee3b8017e8bcca7e91d629e249",
     "wof:hierarchy":[
@@ -172,7 +176,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855868,
+    "wof:lastmodified":1695887199,
     "wof:name":"Utuado",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/435/102080435.geojson
+++ b/data/102/080/435/102080435.geojson
@@ -95,6 +95,10 @@
         "hasc:id":"PR.GR",
         "uscensus:geoid":"72063"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"b1a80c7c0b09d754dff3769a0b819a3b",
     "wof:hierarchy":[
@@ -117,7 +121,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476304,
+    "wof:lastmodified":1695887195,
     "wof:name":"Gurabo",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/437/102080437.geojson
+++ b/data/102/080/437/102080437.geojson
@@ -144,6 +144,10 @@
         "uscensus:geoid":"72093",
         "wd:id":"Q2624359"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"180bbec73a69f9458ff762addef005a0",
     "wof:hierarchy":[
@@ -166,7 +170,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855859,
+    "wof:lastmodified":1695887197,
     "wof:name":"Maricao",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/441/102080441.geojson
+++ b/data/102/080/441/102080441.geojson
@@ -241,6 +241,10 @@
         "hasc:id":"PR.SJ",
         "uscensus:geoid":"72127"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"23835030b3fedad9f4ff487699d38e4c",
     "wof:hierarchy":[
@@ -263,7 +267,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1684476307,
+    "wof:lastmodified":1695887199,
     "wof:name":"San Juan",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/443/102080443.geojson
+++ b/data/102/080/443/102080443.geojson
@@ -195,6 +195,10 @@
         "uscensus:geoid":"72021",
         "wd:id":"Q739675"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"9d85db20a37bf858e3b14f5f6ef45962",
     "wof:hierarchy":[
@@ -217,7 +221,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855866,
+    "wof:lastmodified":1695887193,
     "wof:name":"Bayam\u00f3n",
     "wof:parent_id":85633729,
     "wof:placetype":"county",

--- a/data/102/080/445/102080445.geojson
+++ b/data/102/080/445/102080445.geojson
@@ -135,6 +135,10 @@
         "uscensus:geoid":"72109",
         "wd:id":"Q2485638"
     },
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"PR",
     "wof:geomhash":"f6aad7dcc332f72b748f3d0706fa9675",
     "wof:hierarchy":[
@@ -157,7 +161,7 @@
         "spa",
         "eng"
     ],
-    "wof:lastmodified":1690855867,
+    "wof:lastmodified":1695887198,
     "wof:name":"Patillas",
     "wof:parent_id":85633729,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.